### PR TITLE
3 bug docker healthchecks are failing

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -33,9 +33,6 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
 
 # Secret mount keeps GITHUB_TOKEN out of image layers.
 # Token prevents GitHub API rate-limits that cause the binary download to stall.
-RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
-    bun x camoufox-js fetch \
-    && rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
 
 # ── Stage 3: lean runtime (only API-required files) ────────────────────────────
 FROM ubuntu:22.04
@@ -60,6 +57,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libasound2 \
       fonts-liberation \
       ca-certificates \
+      curl \
     && apt-get clean
 
 COPY --from=oven/bun:1.3.14  /usr/local/bin/bun /usr/local/bin/bun

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -73,19 +73,22 @@ function flareSolverrError(url: string, message: string): FlareSolverrResponse {
 }
 
 new Elysia()
-  .get("/health", () => ({
-    status: pool ? "ok" : "starting",
-    uptime: Math.floor((Date.now() - startTime) / 1000),
-    pool:
-      pool?.getStats() ??
-      ({
-        total: 0,
-        busy: 0,
-        available: 0,
-        restarts: 0,
-        avgRestarts: 0,
-      } satisfies PoolStats),
-  }))
+  .get("/health", ({ set }) => {
+    if (!pool) set.status = 503
+    return {
+      status: pool ? "ok" : "starting",
+      uptime: Math.floor((Date.now() - startTime) / 1000),
+      pool:
+        pool?.getStats() ??
+        ({
+          total: 0,
+          busy: 0,
+          available: 0,
+          restarts: 0,
+          avgRestarts: 0,
+        } satisfies PoolStats),
+    }
+  })
 
   .get("/stats", () => {
     const stats = pool?.getStats() ?? {

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -25,6 +25,12 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
 
   web:
     build:

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -6,3 +6,9 @@ services:
     shm_size: 1gb
     environment:
       BROWSER_POOL_SIZE: 1
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,8 +18,11 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: wget -qO- http://localhost:8191/health
+      test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
       interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
 
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       BROWSER_POOL_SIZE: 3
     depends_on:
       - redis
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
 
 volumes:
   redis_data:


### PR DESCRIPTION
## Summary

- Replaced wget with curl, added to the runtime stage in the Dockerfile
- /health now returns HTTP 503 while the browser pool is initializing (previously always 200, making it impossible for Docker to distinguish "starting" from "ready")
- Added missing timeout, retries, and start_period: 90s to docker-compose.prod.yml — without start_period, Docker would mark the container unhealthy mid-warmup and trigger restart loops
- Added the healthcheck to the three compose files that were missing it entirely (docker-compose.yml, docker-compose.full.yml, docker-compose.minimal.yml)
- Dropped a duplicate bun x camoufox-js fetch call in the Dockerfile build stage that was slipping through without the BuildKit cache mount

## Linked issues

Closes #3

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran bun run check and it passes locally
- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under AGPL-3.0.