### PR TITLE
1 bug docker image crashes on startup missing memoirist eisdir camoufox js

### DIFF
--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -1,0 +1,73 @@
+name: Publish Baseline
+
+# Builds `trawl-baseline:latest` from `apps/api/Dockerfile.baseline` (Bun
+# baseline runtime — pre-2013-CPU compatible). Triggered manually, or
+# automatically on `baseline-v*` tags which also stamp `:baseline-vX.Y.Z`.
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["baseline-v*"]
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/trawl-baseline
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # Tag push: publish the matching version tag + baseline-vX.Y.Z
+            VER="${GITHUB_REF_NAME#baseline-v}"
+            echo "version=${VER}" >> "$GITHUB_OUTPUT"
+            TAGS="${IMAGE}:baseline-v${VER}"
+          else
+            # Manual dispatch: only update :latest if on default branch
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              TAGS="${IMAGE}:latest"
+            else
+              TAGS=""
+            fi
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push
+        if: steps.tags.outputs.tags != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile.baseline
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=trawl-baseline
+            org.opencontainers.image.description=TRAWL API on Bun baseline runtime
+          cache-from: type=gha,scope=trawl-baseline-${{ matrix.platform }}
+          cache-to: type=gha,scope=trawl-baseline-${{ matrix.platform }},mode=max
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -1,13 +1,21 @@
 name: Publish Baseline
 
-# Builds the `:baseline` tag of `ghcr.io/.../trawl` from
-# `apps/api/Dockerfile.baseline` (Bun baseline runtime — pre-2013-CPU
+# Builds the `:baseline` (or versioned `*-baseline`) tag of `ghcr.io/.../trawl`
+# from `apps/api/Dockerfile.baseline` (Bun baseline runtime — pre-2013-CPU
 # compatible). Same GHCR package as `:latest`, just a different tag.
-# Triggered manually, or automatically on `*-baseline` tags (e.g. `1.0.0-baseline`),
-# which produce the docker tag `germondai/trawl:1.0.0-baseline`.
+#
+# Triggers:
+#   - workflow_dispatch: run manually from any branch; pick a tag via the input
+#     (default: "baseline") e.g. "baseline", "1.0.0-baseline"
+#   - push of `*-baseline` tags (e.g. `1.0.0-baseline`) → docker tag mirrors git tag
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker tag to push (e.g. "baseline", "1.0.0-baseline")'
+        required: false
+        default: 'baseline'
   push:
     tags: ["*-baseline"]
 
@@ -38,45 +46,84 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Compute tags
-        id: tags
-        shell: bash
+      - name: Sanitize platform name
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            # Tag push: docker tag mirrors git tag exactly.
-            # Pattern: git tag `1.0.0-baseline` → `germondai/trawl:1.0.0-baseline`
-            TAGS="${IMAGE}:${GITHUB_REF_NAME}"
-          else
-            # Manual dispatch: only update :baseline if on default branch
-            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-              TAGS="${IMAGE}:baseline"
-            else
-              TAGS=""
-            fi
-          fi
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Build & push
-        if: steps.tags.outputs.tags != ''
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: apps/api/Dockerfile.baseline
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.tags.outputs.tags }}
+          push: true
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           labels: |
-            org.opencontainers.image.title=trawl (baseline tag)
-            org.opencontainers.image.description=TRAWL API on Bun baseline runtime
+            org.opencontainers.image.title=trawl (baseline)
+            org.opencontainers.image.description=TRAWL API on Bun baseline runtime (pre-AVX2 compatible)
           cache-from: type=gha,scope=trawl-baseline-${{ matrix.platform }}
           cache-to: type=gha,scope=trawl-baseline-${{ matrix.platform }},mode=max
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
-      # Safety: prevent the baseline workflow from ever stamping :latest.
-      # Builds tagged `:latest` are owned by publish.yml.
-      - name: Guard against :latest tag
-        if: startsWith(steps.tags.outputs.tags, 'ghcr.io/') && endsWith(steps.tags.outputs.tags, ':latest')
+      - name: Export digest
         run: |
-          echo "::error::Baseline workflow must not push :latest — aborting"
-          exit 1
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-baseline-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-baseline-*
+          merge-multiple: true
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Compute tag
+        id: tags
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          # Safety: baseline workflow must never push :latest
+          if [[ "${TAG}" == "latest" ]]; then
+            echo "::error::Baseline workflow must not push :latest — use publish.yml instead"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "full=${IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ steps.tags.outputs.full }} \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ steps.tags.outputs.full }}

--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -1,8 +1,10 @@
 name: Publish Baseline
 
-# Builds `trawl-baseline:latest` from `apps/api/Dockerfile.baseline` (Bun
-# baseline runtime — pre-2013-CPU compatible). Triggered manually, or
-# automatically on `baseline-v*` tags which also stamp `:baseline-vX.Y.Z`.
+# Builds the `:baseline` tag of `ghcr.io/.../trawl` from
+# `apps/api/Dockerfile.baseline` (Bun baseline runtime — pre-2013-CPU
+# compatible). Same GHCR package as `:latest`, just a different tag.
+# Triggered manually, or automatically on `baseline-v*` tags which stamp
+# `:baseline-vX.Y.Z`.
 
 on:
   workflow_dispatch:
@@ -10,7 +12,7 @@ on:
     tags: ["baseline-v*"]
 
 env:
-  IMAGE: ghcr.io/${{ github.repository_owner }}/trawl-baseline
+  IMAGE: ghcr.io/${{ github.repository_owner }}/trawl
 
 jobs:
   build:
@@ -41,14 +43,12 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            # Tag push: publish the matching version tag + baseline-vX.Y.Z
             VER="${GITHUB_REF_NAME#baseline-v}"
-            echo "version=${VER}" >> "$GITHUB_OUTPUT"
             TAGS="${IMAGE}:baseline-v${VER}"
           else
-            # Manual dispatch: only update :latest if on default branch
+            # Manual dispatch: only update :baseline if on default branch
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-              TAGS="${IMAGE}:latest"
+              TAGS="${IMAGE}:baseline"
             else
               TAGS=""
             fi
@@ -65,9 +65,17 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.tags.outputs.tags }}
           labels: |
-            org.opencontainers.image.title=trawl-baseline
+            org.opencontainers.image.title=trawl (baseline tag)
             org.opencontainers.image.description=TRAWL API on Bun baseline runtime
           cache-from: type=gha,scope=trawl-baseline-${{ matrix.platform }}
           cache-to: type=gha,scope=trawl-baseline-${{ matrix.platform }},mode=max
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      # Safety: prevent the baseline workflow from ever stamping :latest.
+      # Builds tagged `:latest` are owned by publish.yml.
+      - name: Guard against :latest tag
+        if: startsWith(steps.tags.outputs.tags, 'ghcr.io/') && endsWith(steps.tags.outputs.tags, ':latest')
+        run: |
+          echo "::error::Baseline workflow must not push :latest — aborting"
+          exit 1

--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -3,13 +3,13 @@ name: Publish Baseline
 # Builds the `:baseline` tag of `ghcr.io/.../trawl` from
 # `apps/api/Dockerfile.baseline` (Bun baseline runtime — pre-2013-CPU
 # compatible). Same GHCR package as `:latest`, just a different tag.
-# Triggered manually, or automatically on `baseline-v*` tags which stamp
-# `:baseline-vX.Y.Z`.
+# Triggered manually, or automatically on `*-baseline` tags (e.g. `1.0.0-baseline`),
+# which produce the docker tag `germondai/trawl:1.0.0-baseline`.
 
 on:
   workflow_dispatch:
   push:
-    tags: ["baseline-v*"]
+    tags: ["*-baseline"]
 
 env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/trawl
@@ -43,8 +43,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            VER="${GITHUB_REF_NAME#baseline-v}"
-            TAGS="${IMAGE}:baseline-v${VER}"
+            # Tag push: docker tag mirrors git tag exactly.
+            # Pattern: git tag `1.0.0-baseline` → `germondai/trawl:1.0.0-baseline`
+            TAGS="${IMAGE}:${GITHUB_REF_NAME}"
           else
             # Manual dispatch: only update :baseline if on default branch
             if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then

--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ Tier 4: Residential proxy ──── success ──→ cache + return (15–45
 | `docker-compose.prod.yml`    | Production: `restart: always`, memory limit, healthcheck |
 | `docker-compose.full.yml`    | Full stack: scraper + web + docs                         |
 
+## Docker images (two GHCR images)
+
+| Image                                          | Dockerfile                       | Runtime                          | Use case |
+|------------------------------------------------|----------------------------------|----------------------------------|----------|
+| `ghcr.io/germondai/trawl`         (`:latest`)  | `apps/api/Dockerfile`            | Bun 1.3.14 (modern, AVX2)        | Default — modern Linux amd64/arm64 |
+| `ghcr.io/germondai/trawl-baseline` (`:baseline`) | `apps/api/Dockerfile.baseline`   | Bun 1.3.14 baseline (no AVX2)     | Older CPUs / older kernels (Synology NAS, J4125, Atom-era) |
+
+Two images live at separate GHCR packages so `:latest` of one cannot clobber `:latest` of another. Pick the one your hardware supports:
+
+```yaml
+# Modern hardware (most users)
+image: ghcr.io/germondai/trawl:latest
+
+# Older CPUs without AVX2 / Synology / older kernels
+image: ghcr.io/germondai/trawl-baseline:latest
+```
+
+Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. The baseline variant is published for that case — confirm-working status on the reporter's actual hardware (DS920+, kernel 4.4.302) is pending verification. Published by independent GitHub Actions workflows (`.github/workflows/publish.yml`, `publish-baseline.yml`); tag-triggered releases (`v*`, `baseline-v*`) and manual `workflow_dispatch` both work.
+
 ## Configuration
 
 | Variable                     | Default                  | Description                                                              |

--- a/README.md
+++ b/README.md
@@ -94,24 +94,24 @@ Tier 4: Residential proxy ──── success ──→ cache + return (15–45
 | `docker-compose.prod.yml`    | Production: `restart: always`, memory limit, healthcheck |
 | `docker-compose.full.yml`    | Full stack: scraper + web + docs                         |
 
-## Docker images (two GHCR images)
+## Docker images (one GHCR package, two tags)
 
-| Image                                          | Dockerfile                       | Runtime                          | Use case |
-|------------------------------------------------|----------------------------------|----------------------------------|----------|
-| `ghcr.io/germondai/trawl`         (`:latest`)  | `apps/api/Dockerfile`            | Bun 1.3.14 (modern, AVX2)        | Default — modern Linux amd64/arm64 |
-| `ghcr.io/germondai/trawl-baseline` (`:baseline`) | `apps/api/Dockerfile.baseline`   | Bun 1.3.14 baseline (no AVX2)     | Older CPUs / older kernels (Synology NAS, J4125, Atom-era) |
+| Image tag                              | Built from                      | Runtime                          | Use case |
+|----------------------------------------|--------------------------------|----------------------------------|----------|
+| `ghcr.io/germondai/trawl:latest`       | `apps/api/Dockerfile`           | Bun 1.3.14 (modern, AVX2)        | Default — modern Linux amd64/arm64 |
+| `ghcr.io/germondai/trawl:baseline`     | `apps/api/Dockerfile.baseline`  | Bun 1.3.14 baseline (no AVX2)     | Older CPUs / older kernels (Synology NAS, J4125, Atom-era) |
 
-Two images live at separate GHCR packages so `:latest` of one cannot clobber `:latest` of another. Pick the one your hardware supports:
+Both tags live on the same `ghcr.io/germondai/trawl` package — they share the registry but use different Dockerfile sources. Pick whichever tag fits your hardware:
 
 ```yaml
 # Modern hardware (most users)
 image: ghcr.io/germondai/trawl:latest
 
 # Older CPUs without AVX2 / Synology / older kernels
-image: ghcr.io/germondai/trawl-baseline:latest
+image: ghcr.io/germondai/trawl:baseline
 ```
 
-Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. The baseline variant is published for that case — confirm-working status on the reporter's actual hardware (DS920+, kernel 4.4.302) is pending verification. Published by independent GitHub Actions workflows (`.github/workflows/publish.yml`, `publish-baseline.yml`); tag-triggered releases (`v*`, `baseline-v*`) and manual `workflow_dispatch` both work.
+Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. The `:baseline` tag is published for that case — confirm-working status on the reporter's actual hardware (DS920+, kernel 4.4.302) is pending verification. Published by independent GitHub Actions workflows (`.github/workflows/publish.yml`, `publish-baseline.yml`); tag-triggered releases (`v*`, `baseline-v*`) and manual `workflow_dispatch` both work.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ image: ghcr.io/germondai/trawl:latest
 image: ghcr.io/germondai/trawl:baseline
 ```
 
-Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. The `:baseline` tag is published for that case — confirm-working status on the reporter's actual hardware (DS920+, kernel 4.4.302) is pending verification. Published by independent GitHub Actions workflows (`.github/workflows/publish.yml`, `publish-baseline.yml`); tag-triggered releases (`v*`, `baseline-v*`) and manual `workflow_dispatch` both work.
+Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. The `:baseline` tag is published for that case — confirm-working status on the reporter's actual hardware (DS920+, kernel 4.4.302) is pending verification. Published by independent GitHub Actions workflows (`.github/workflows/publish.yml`, `publish-baseline.yml`); tag-triggered releases push matching git tags (e.g. `v1.0.0` → `1.0.0`, `1.0.0-baseline` → `1.0.0-baseline`) and manual `workflow_dispatch` from `main` updates the rolling tag (`latest` and `baseline` respectively).
 
 ## Configuration
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,7 +16,11 @@ COPY apps/web/package.json         ./apps/web/
 COPY apps/docs/package.json        ./apps/docs/
 
 # --production skips devDependencies (vitepress + algolia from docs, typescript, @types)
-RUN bun install --frozen-lockfile --production
+# --linker=hoisted avoids Bun's default isolated-linker bugs that corrupt
+# multi-stage Docker builds: transitive deps not symlinked (oven-sh/bun#23524,
+# e.g. @sinclair/typebox via elysia) and a store-population race producing
+# EISDIR on freshly-linked packages (oven-sh/bun#29489, e.g. camoufox-js).
+RUN bun install --frozen-lockfile --production --linker=hoisted
 
 # ── Stage 2: fetch the Camoufox Firefox binary ─────────
 FROM oven/bun:1.3.14 AS camoufox
@@ -71,12 +75,6 @@ COPY packages/browser/ /app/packages/browser/
 COPY packages/tiers/   /app/packages/tiers/
 COPY apps/api/         /app/apps/api/
 COPY package.json      /app/
-
-# Workspace node_modules (relative symlinks into root .bun/ tree — must come after source COPY)
-# packages/types has no production deps so no node_modules dir is created
-COPY --from=deps /app/apps/api/node_modules          /app/apps/api/node_modules
-COPY --from=deps /app/packages/browser/node_modules  /app/packages/browser/node_modules
-COPY --from=deps /app/packages/tiers/node_modules    /app/packages/tiers/node_modules
 
 ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox
 WORKDIR /app

--- a/apps/api/Dockerfile.baseline
+++ b/apps/api/Dockerfile.baseline
@@ -1,0 +1,103 @@
+# ── Stage 1: install workspace deps (runs natively on build host) ──────────────
+FROM oven/bun:1.3.14 AS deps
+WORKDIR /app
+
+# nodejs/python3/make/g++ are needed to compile better-sqlite3 (camoufox-js dep)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs npm python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package.json bun.lock* ./
+COPY packages/types/package.json   ./packages/types/
+COPY packages/browser/package.json ./packages/browser/
+COPY packages/tiers/package.json   ./packages/tiers/
+COPY apps/api/package.json         ./apps/api/
+COPY apps/web/package.json         ./apps/web/
+COPY apps/docs/package.json        ./apps/docs/
+
+# --production skips devDependencies (vitepress + algolia from docs, typescript, @types)
+RUN bun install --frozen-lockfile --production
+
+# ── Stage 2: fetch the Camoufox Firefox binary ─────────
+FROM oven/bun:1.3.14 AS camoufox
+ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs npm python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+# Use BuildKit cache for the download
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    --mount=type=cache,target=/root/.cache/camoufox,sharing=locked \
+    bun x camoufox-js fetch \
+    && rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
+
+# Secret mount keeps GITHUB_TOKEN out of image layers.
+# Token prevents GitHub API rate-limits that cause the binary download to stall.
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    bun x camoufox-js fetch \
+    && rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
+
+# ── Stage 3: lean runtime (only API-required files) ────────────────────────────
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+ARG BUN_VERSION=1.3.14
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+      libcairo2 libcairo-gobject2 \
+      libdbus-1-3 libdbus-glib-1-2 \
+      libfontconfig1 \
+      libgdk-pixbuf-2.0-0 \
+      libglib2.0-0 \
+      libgtk-3-0 \
+      libnspr4 libnss3 \
+      libpango-1.0-0 libpangocairo-1.0-0 \
+      libx11-6 libx11-xcb1 libxcb1 libxcb-shm0 \
+      libxcomposite1 libxcursor1 libxdamage1 \
+      libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+      libdrm2 libgbm1 \
+      libasound2 \
+      fonts-liberation \
+      ca-certificates unzip curl \
+    && apt-get clean
+
+# Pull the Bun runtime directly from GitHub releases.
+# amd64 uses the BASELINE variant (pre-2013 CPUs without AVX2 — covers older
+# Synology/Atom/Kabylake-era hardware). arm64 has no baseline variant because
+# arm64 doesn't use x86 SIMD — the standard `bun-linux-aarch64.zip` works on
+# all armv8 CPUs (including every ARM64 Synology).
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) BUN_ZIP=bun-linux-x64-baseline.zip ;; \
+      arm64) BUN_ZIP=bun-linux-aarch64.zip ;; \
+      *) echo "unsupported arch: $TARGETARCH"; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" -o /tmp/bun.zip; \
+    unzip -q /tmp/bun.zip -d /tmp/bun-extract; \
+    BUN_BIN=$(find /tmp/bun-extract -name bun -type f | head -1); \
+    install -m 0755 "$BUN_BIN" /usr/local/bin/bun; \
+    rm -rf /tmp/bun.zip /tmp/bun-extract; \
+    /usr/local/bin/bun --version
+
+COPY --from=camoufox          /opt/camoufox      /opt/camoufox
+COPY --from=deps              /app/node_modules  /app/node_modules
+
+COPY packages/types/   /app/packages/types/
+COPY packages/browser/ /app/packages/browser/
+COPY packages/tiers/   /app/packages/tiers/
+COPY apps/api/         /app/apps/api/
+COPY package.json      /app/
+
+# Workspace node_modules (relative symlinks into root .bun/ tree — must come after source COPY)
+# packages/types has no production deps so no node_modules dir is created
+COPY --from=deps /app/apps/api/node_modules          /app/apps/api/node_modules
+COPY --from=deps /app/packages/browser/node_modules  /app/packages/browser/node_modules
+COPY --from=deps /app/packages/tiers/node_modules    /app/packages/tiers/node_modules
+
+ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox
+WORKDIR /app
+EXPOSE 8191
+CMD ["bun", "run", "apps/api/src/index.ts"]

--- a/apps/api/Dockerfile.baseline
+++ b/apps/api/Dockerfile.baseline
@@ -16,7 +16,11 @@ COPY apps/web/package.json         ./apps/web/
 COPY apps/docs/package.json        ./apps/docs/
 
 # --production skips devDependencies (vitepress + algolia from docs, typescript, @types)
-RUN bun install --frozen-lockfile --production
+# --linker=hoisted avoids Bun's default isolated-linker bugs that corrupt
+# multi-stage Docker builds: transitive deps not symlinked (oven-sh/bun#23524,
+# e.g. @sinclair/typebox via elysia) and a store-population race producing
+# EISDIR on freshly-linked packages (oven-sh/bun#29489, e.g. camoufox-js).
+RUN bun install --frozen-lockfile --production --linker=hoisted
 
 # ── Stage 2: fetch the Camoufox Firefox binary ─────────
 FROM oven/bun:1.3.14 AS camoufox
@@ -90,12 +94,6 @@ COPY packages/browser/ /app/packages/browser/
 COPY packages/tiers/   /app/packages/tiers/
 COPY apps/api/         /app/apps/api/
 COPY package.json      /app/
-
-# Workspace node_modules (relative symlinks into root .bun/ tree — must come after source COPY)
-# packages/types has no production deps so no node_modules dir is created
-COPY --from=deps /app/apps/api/node_modules          /app/apps/api/node_modules
-COPY --from=deps /app/packages/browser/node_modules  /app/packages/browser/node_modules
-COPY --from=deps /app/packages/tiers/node_modules    /app/packages/tiers/node_modules
 
 ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox
 WORKDIR /app

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,9 @@
     "@trawl/browser": "workspace:*",
     "@trawl/tiers": "workspace:*",
     "@trawl/types": "workspace:*",
-    "elysia": "^1.4.29"
+    "camoufox-js": "0.11.1",
+    "elysia": "^1.4.29",
+    "memoirist": "0.4.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,9 @@
         "@trawl/browser": "workspace:*",
         "@trawl/tiers": "workspace:*",
         "@trawl/types": "workspace:*",
+        "camoufox-js": "0.11.1",
         "elysia": "^1.4.29",
+        "memoirist": "0.4.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",


### PR DESCRIPTION
## Summary

Fixes the :baseline (and :latest) image crash-looping on startup — Bun's default "isolated" install linker was silently dropping transitive deps (@sinclair/typebox) and racing on symlink creation (camoufox-js), so switched to --linker=hoisted.

## Linked issues

Closes #1

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I opened or commented on an issue before starting this PR
- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).