### PR TITLE
feat: add post method with postData parameter

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -129,6 +129,8 @@ new Elysia()
           url: req.url,
           maxTimeout: req.maxTimeout ?? 60_000,
           headers: req.headers,
+          method: cmd === "request.post" ? "POST" : "GET",
+          postData: req.postData,
         },
         getDeps(),
       )

--- a/apps/web/app/components/CtaSection.vue
+++ b/apps/web/app/components/CtaSection.vue
@@ -124,7 +124,8 @@ const tabs: { id: Tab; label: string; hint: string }[] = [
 
         <p class="tag-hint">
           Older hardware or a Synology NAS without AVX2 / kernel &lt; 5.1? Swap <code>:latest</code> for
-          <code>:baseline</code> in the image tag above — degrades gracefully down to kernel 3.10 —
+          <code>:baseline</code>
+          in the image tag above — degrades gracefully down to kernel 3.10 —
           <a :href="`${docsUrl}/deployment/standalone#older-cpus-synology-nas`">same commands, different runtime</a>.
         </p>
 

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -40,7 +40,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
 
   // Tier 1: plain HTTP fetch
   if (!req.skipHttp && maxTier >= 1) {
-    const t1 = await runTier1(req.url, req.headers)
+    const t1 = await runTier1(req.url, req.headers, req.method, req.postData)
     emit(t1)
     if (t1.status === "success" && t1.html !== undefined) {
       return {
@@ -69,7 +69,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     const session = await deps.loadSession(domain)
     if (session && maxTier >= 2) {
       const remaining = maxTimeout - (Date.now() - totalStart)
-      const t2 = await runTier2(req.url, handle, session, remaining, req.headers)
+      const t2 = await runTier2(req.url, handle, session, remaining, req.headers, req.method, req.postData)
       emit(t2)
       if (t2.status === "success" && t2.html !== undefined) {
         if (t2.cookies && t2.cookies.length > 0) {
@@ -102,7 +102,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
 
     // Tier 3: fresh challenge solve
     const remaining3 = maxTimeout - (Date.now() - totalStart)
-    const t3 = await runTier3(req.url, handle, remaining3, deps.proxyUrl, req.headers)
+    const t3 = await runTier3(req.url, handle, remaining3, deps.proxyUrl, req.headers, req.method, req.postData)
     emit(t3)
     if (t3.status === "success" && t3.html !== undefined) {
       const cookies: Cookie[] = t3.cookies ?? []
@@ -141,7 +141,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     console.log(`[orchestrator] Tier 4 via residential proxy: ${proxyUrl.replace(/\/\/[^@]*@/, "//**@")}`)
 
     const remaining4 = maxTimeout - (Date.now() - totalStart)
-    const t4 = await runTier4(req.url, handle, remaining4, proxyUrl, req.headers)
+    const t4 = await runTier4(req.url, handle, remaining4, proxyUrl, req.headers, req.method, req.postData)
     emit(t4)
     if (t4.status === "success" && t4.html !== undefined) {
       const cookies: Cookie[] = t4.cookies ?? []

--- a/packages/tiers/src/tier1.ts
+++ b/packages/tiers/src/tier1.ts
@@ -9,10 +9,17 @@ export interface Tier1Result extends TierResult {
   statusCode?: number
 }
 
-export async function runTier1(url: string, extraHeaders?: Record<string, string>): Promise<Tier1Result> {
+export async function runTier1(
+  url: string,
+  extraHeaders?: Record<string, string>,
+  method?: string,
+  postData?: string,
+): Promise<Tier1Result> {
   const start = Date.now()
   try {
     const res = await fetch(url, {
+      method: method ?? "GET",
+      body: method === "POST" ? postData : undefined,
       headers: {
         "User-Agent": FINGERPRINT.userAgent,
         Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",

--- a/packages/tiers/src/tier2.ts
+++ b/packages/tiers/src/tier2.ts
@@ -18,6 +18,8 @@ export async function runTier2(
   session: SessionData,
   maxTimeout: number,
   extraHeaders?: Record<string, string>,
+  method?: string,
+  postData?: string,
 ): Promise<Tier2Result> {
   const start = Date.now()
   const page = await handle.context.newPage()
@@ -41,11 +43,25 @@ export async function runTier2(
 
     await page.setExtraHTTPHeaders({ "User-Agent": session.userAgent })
 
-    if (extraHeaders && Object.keys(extraHeaders).length > 0) {
+    if ((extraHeaders && Object.keys(extraHeaders).length > 0) || method === "POST") {
       await page.route(
         url,
-        (route: { request(): { headers(): Record<string, string> }; continue(o: object): Promise<void> }) =>
-          route.continue({ headers: { ...route.request().headers(), ...extraHeaders } }),
+        (route: {
+          request(): { headers(): Record<string, string>; method(): string }
+          continue(o: object): Promise<void>
+        }) => {
+          const overrides: { method?: string; postData?: string; headers: Record<string, string> } = {
+            headers: { ...route.request().headers(), ...extraHeaders },
+          }
+          if (method === "POST" && route.request().method() === "GET") {
+            overrides.method = "POST"
+            overrides.postData = postData
+            if (!overrides.headers["content-type"] && !overrides.headers["Content-Type"]) {
+              overrides.headers["Content-Type"] = "application/x-www-form-urlencoded"
+            }
+          }
+          return route.continue(overrides)
+        },
       )
     }
 

--- a/packages/tiers/src/tier3.ts
+++ b/packages/tiers/src/tier3.ts
@@ -21,6 +21,8 @@ export async function runTier3(
   maxTimeout: number,
   _proxyUrl?: string,
   extraHeaders?: Record<string, string>,
+  method?: string,
+  postData?: string,
 ): Promise<Tier3Result> {
   const start = Date.now()
 
@@ -33,11 +35,25 @@ export async function runTier3(
   const page = await freshCtx.newPage()
 
   try {
-    if (extraHeaders && Object.keys(extraHeaders).length > 0) {
+    if ((extraHeaders && Object.keys(extraHeaders).length > 0) || method === "POST") {
       await page.route(
         url,
-        (route: { request(): { headers(): Record<string, string> }; continue(o: object): Promise<void> }) =>
-          route.continue({ headers: { ...route.request().headers(), ...extraHeaders } }),
+        (route: {
+          request(): { headers(): Record<string, string>; method(): string }
+          continue(o: object): Promise<void>
+        }) => {
+          const overrides: { method?: string; postData?: string; headers: Record<string, string> } = {
+            headers: { ...route.request().headers(), ...extraHeaders },
+          }
+          if (method === "POST" && route.request().method() === "GET") {
+            overrides.method = "POST"
+            overrides.postData = postData
+            if (!overrides.headers["content-type"] && !overrides.headers["Content-Type"]) {
+              overrides.headers["Content-Type"] = "application/x-www-form-urlencoded"
+            }
+          }
+          return route.continue(overrides)
+        },
       )
     }
 

--- a/packages/tiers/src/tier4.ts
+++ b/packages/tiers/src/tier4.ts
@@ -19,6 +19,8 @@ export async function runTier4(
   maxTimeout: number,
   proxyUrl: string,
   extraHeaders?: Record<string, string>,
+  method?: string,
+  postData?: string,
 ): Promise<Tier4Result> {
   const start = Date.now()
 
@@ -55,11 +57,25 @@ export async function runTier4(
 
     const page = await proxyContext.newPage()
 
-    if (extraHeaders && Object.keys(extraHeaders).length > 0) {
+    if ((extraHeaders && Object.keys(extraHeaders).length > 0) || method === "POST") {
       await page.route(
         url,
-        (route: { request(): { headers(): Record<string, string> }; continue(o: object): Promise<void> }) =>
-          route.continue({ headers: { ...route.request().headers(), ...extraHeaders } }),
+        (route: {
+          request(): { headers(): Record<string, string>; method(): string }
+          continue(o: object): Promise<void>
+        }) => {
+          const overrides: { method?: string; postData?: string; headers: Record<string, string> } = {
+            headers: { ...route.request().headers(), ...extraHeaders },
+          }
+          if (method === "POST" && route.request().method() === "GET") {
+            overrides.method = "POST"
+            overrides.postData = postData
+            if (!overrides.headers["content-type"] && !overrides.headers["Content-Type"]) {
+              overrides.headers["Content-Type"] = "application/x-www-form-urlencoded"
+            }
+          }
+          return route.continue(overrides)
+        },
       )
     }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,8 @@ export interface ScrapeRequest {
   maxTier?: 1 | 2 | 3 | 4
   sessionId?: string
   headers?: Record<string, string>
+  method?: string
+  postData?: string
 }
 
 export interface TierResult {


### PR DESCRIPTION
## Summary

<!-- One or two sentences. What does this PR do, and why? -->
Adds native support for HTTP POST requests and form submissions across all execution tiers. This ensures that the `/v1` FlareSolverr-compatible `request.post` command functions properly, allowing for complex bypasses like Cloudflare-gated login flows by gracefully injecting `postData` into the browser context without triggering TLS fingerprinting mismatch errors.

## Linked issues

<!-- Closes #123, fixes #456, or "n/a — discussed in #789". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [ ] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [ ] I added or updated tests for the behavior change (if applicable)
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).