### PR TITLE
12 bug 500 internalservererror in prowlarr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cookies, overriding the per-tier `User-Agent`, or rewriting routing signals
   (`X-Forwarded-For`, `Host`) during a POST bypass flow
 
+### Fixed
+- `/v1` now accepts Prowlarr's Cardigann `FlareSolverrProxy` object shape
+  (`{url, username, password}`) for the per-request `proxy` field, instead of
+  crashing with `proxy.server: expected string, got object` when Prowlarr sends
+  it through (issue #12). The boundary normalises both the object form and a
+  plain URL string into a single URL string before the orchestrator forwards
+  it to Playwright/Camoufox. Credentials are URL-encoded so embedded `@`/`:`
+  characters survive the round-trip.
+
 ### Limitations
 - The Playwright `page.route(url, …)` interceptor only handles the first
   top-frame GET to that exact URL. Server redirects to a different URL, XHR

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { BrowserPool, PoolExhaustedError, SessionCache } from "@trawl/browser"
 import {
   isValidMethod,
+  normalizeProxy,
   ProxyPool,
   RequestValidationError,
   requireContentTypeForBody,
@@ -81,7 +82,11 @@ function buildScrapeRequestFromFlareSolverr(req: FlareSolverrRequest): ScrapeReq
     headers,
     method,
     body: req.postData,
-    proxy: req.proxy,
+    // Prowlarr's Cardigann flow serializes proxy as {url, username, password};
+    // other callers may send a plain URL string. Normalize to a single URL string
+    // here so downstream Playwright/Camoufox `newContext({proxy})` calls receive
+    // a string (issue #12 — proxy.server: expected string, got object).
+    proxy: normalizeProxy(req.proxy),
   }
 }
 

--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -10,7 +10,7 @@ export {
 } from "./detect"
 export type { OrchestratorDeps } from "./orchestrator"
 export { scrape } from "./orchestrator"
-export { ProxyPool } from "./proxyRotator"
+export { normalizeProxy, ProxyPool } from "./proxyRotator"
 export {
   isValidMethod,
   RESERVED_HEADER_NAMES,

--- a/packages/tiers/src/proxyRotator.ts
+++ b/packages/tiers/src/proxyRotator.ts
@@ -3,8 +3,39 @@
 // fetches or trusts any third-party proxy list.
 
 import { readFileSync } from "node:fs"
+import type { ProxyEndpointInput } from "@trawl/types"
 
 const COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes — matches the plan's "time-boxed cooldown"
+
+// Normalizes the per-request `proxy` field at the API boundary into a single URL string.
+// Prowlarr's Cardigann flow serializes proxy config as an object {url, username, password};
+// other callers send a plain URL string. Playwright's `newContext({proxy})` expects
+// `server` to be a string — passing the object through untyped crashes with
+// `proxy.server: expected string, got object` (issue #12).
+//
+// Returns undefined for null/undefined/empty/non-string-non-object inputs.
+// Credentials (if present in the object form) are URL-encoded and embedded into the URL
+// so downstream code keeps treating proxy as a single string.
+export function normalizeProxy(input: ProxyEndpointInput | null | undefined): string | undefined {
+  if (input == null) return undefined
+  if (typeof input === "string") {
+    const trimmed = input.trim()
+    return trimmed ? trimmed : undefined
+  }
+  if (typeof input === "object") {
+    const server =
+      typeof input.url === "string" ? input.url : typeof input.server === "string" ? input.server : undefined
+    if (!server) return undefined
+    const user = typeof input.username === "string" && input.username.length > 0 ? input.username : undefined
+    const pass = typeof input.password === "string" && input.password.length > 0 ? input.password : undefined
+    if (!user && !pass) return server
+    const schemeMatch = server.match(/^([a-z][a-z0-9+\-.]*:\/\/)(.*)$/i)
+    if (!schemeMatch) return server
+    const creds = `${encodeURIComponent(user ?? "")}:${encodeURIComponent(pass ?? "")}`
+    return `${schemeMatch[1]}${creds}@${schemeMatch[2]}`
+  }
+  return undefined
+}
 
 interface ProxyState {
   url: string

--- a/packages/tiers/tests/normalizeProxy.test.ts
+++ b/packages/tiers/tests/normalizeProxy.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeProxy } from "../src/proxyRotator"
+
+// Covers issue #12: Prowlarr's Cardigann flow serializes `proxy` as an object
+// {url, username, password}; other callers send a plain URL string. The API
+// boundary must normalize both into a single URL string before the orchestrator
+// hands the value to Playwright/Camoufox `newContext({proxy})` (which requires
+// `server` to be a string).
+describe("normalizeProxy", () => {
+  describe("nullish / empty inputs", () => {
+    test("undefined → undefined", () => {
+      expect(normalizeProxy(undefined)).toBeUndefined()
+    })
+
+    test("null → undefined", () => {
+      expect(normalizeProxy(null)).toBeUndefined()
+    })
+
+    test("empty string → undefined", () => {
+      expect(normalizeProxy("")).toBeUndefined()
+    })
+
+    test("whitespace-only string → undefined", () => {
+      expect(normalizeProxy("   ")).toBeUndefined()
+    })
+
+    test("empty object → undefined", () => {
+      expect(normalizeProxy({})).toBeUndefined()
+    })
+
+    test("object with neither url nor server → undefined", () => {
+      expect(normalizeProxy({ username: "u", password: "p" })).toBeUndefined()
+    })
+  })
+
+  describe("plain URL string (legacy / non-Prowlarr callers)", () => {
+    test("passes a simple URL through unchanged", () => {
+      expect(normalizeProxy("http://proxy.example.com:8080")).toBe("http://proxy.example.com:8080")
+    })
+
+    test("trims surrounding whitespace", () => {
+      expect(normalizeProxy("  http://proxy.example.com:8080  ")).toBe("http://proxy.example.com:8080")
+    })
+
+    test("preserves embedded credentials in URL string", () => {
+      expect(normalizeProxy("http://user:pass@proxy.example.com:8080")).toBe("http://user:pass@proxy.example.com:8080")
+    })
+  })
+
+  describe("Prowlarr object form {url, username, password}", () => {
+    test("object with only url → returns url as-is", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080" })).toBe("http://proxy.example.com:8080")
+    })
+
+    test("object with url + username + password → embeds credentials in URL", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "alice", password: "secret" })).toBe(
+        "http://alice:secret@proxy.example.com:8080",
+      )
+    })
+
+    test("object with url + username (no password) → embeds username only", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "alice" })).toBe(
+        "http://alice:@proxy.example.com:8080",
+      )
+    })
+
+    test("object with url + password (no username) → embeds password only", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", password: "secret" })).toBe(
+        "http://:secret@proxy.example.com:8080",
+      )
+    })
+
+    test("object with empty-string username/password → returns url as-is", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "", password: "" })).toBe(
+        "http://proxy.example.com:8080",
+      )
+    })
+  })
+
+  describe("alternate object form {server, ...}", () => {
+    test("accepts `server` field in place of `url`", () => {
+      expect(normalizeProxy({ server: "http://proxy.example.com:8080" })).toBe("http://proxy.example.com:8080")
+    })
+
+    test("prefers `url` over `server` when both are present", () => {
+      expect(
+        normalizeProxy({ url: "http://primary.example.com:8080", server: "http://fallback.example.com:8080" }),
+      ).toBe("http://primary.example.com:8080")
+    })
+  })
+
+  describe("credential encoding", () => {
+    test("URL-encodes '@' in password", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "alice", password: "p@ss" })).toBe(
+        "http://alice:p%40ss@proxy.example.com:8080",
+      )
+    })
+
+    test("URL-encodes ':' in password", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "alice", password: "pa:ss" })).toBe(
+        "http://alice:pa%3Ass@proxy.example.com:8080",
+      )
+    })
+
+    test("URL-encodes special characters in username", () => {
+      expect(normalizeProxy({ url: "http://proxy.example.com:8080", username: "user@org", password: "secret" })).toBe(
+        "http://user%40org:secret@proxy.example.com:8080",
+      )
+    })
+
+    test("preserves https scheme", () => {
+      expect(normalizeProxy({ url: "https://proxy.example.com:443", username: "u", password: "p" })).toBe(
+        "https://u:p@proxy.example.com:443",
+      )
+    })
+
+    test("preserves socks5 scheme", () => {
+      expect(normalizeProxy({ url: "socks5://proxy.example.com:1080", username: "u", password: "p" })).toBe(
+        "socks5://u:p@proxy.example.com:1080",
+      )
+    })
+  })
+
+  describe("malformed inputs (defensive)", () => {
+    test("server-only object with no recognised fields → undefined", () => {
+      expect(normalizeProxy({ username: "u", password: "p" })).toBeUndefined()
+    })
+
+    test("non-string url field → undefined", () => {
+      expect(normalizeProxy({ url: 42 as unknown as string })).toBeUndefined()
+    })
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -68,6 +68,12 @@ export interface PoolStats {
   avgRestarts: number
 }
 
+// Per-request proxy override as it arrives at the API. Prowlarr's Cardigann flow
+// serializes this as an object (its FlareSolverrProxy class: {url, username, password}).
+// Other callers may send a plain URL string. The API boundary normalizes both forms
+// into a single URL string before handing off to the orchestrator.
+export type ProxyEndpointInput = string | { url?: string; server?: string; username?: string; password?: string }
+
 export interface FlareSolverrRequest {
   cmd?: "request.get" | "request.post"
   url: string
@@ -75,7 +81,8 @@ export interface FlareSolverrRequest {
   postData?: string
   headers?: Record<string, string>
   // TRAWL extension (not part of the FlareSolverr v2 contract) — per-request proxy override.
-  proxy?: string
+  // Accepts Prowlarr's {url, username, password} object shape OR a plain URL string.
+  proxy?: ProxyEndpointInput
 }
 
 export interface FlareSolverrResponse {


### PR DESCRIPTION
## Summary

Fixes #12 — Prowlarr's Cardigann indexer flow crashes with `proxy.server: expected string, got object` because its `FlareSolverrProxy` class serializes per-request proxy config as an object (`{url, username, password}`), but TRAWL's `FlareSolverrRequest.proxy` was typed as `string`. The object passed through unchecked and exploded inside Playwright/Camoufox's `newContext({proxy})` validation. This PR adds a `normalizeProxy()` normaliser at the API boundary that accepts either form (object or string) and emits a single URL string with URL-encoded credentials before the orchestrator hands it to the browser layer.

## Linked issues

Closes #12

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).