### PR TITLE
20 bug trawl fails to start   issues with healtcheck

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -67,6 +67,21 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     chmod -R 755 /opt/camoufox && \
     rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
 
+# Bake the GeoIP database so camoufox-js never downloads it at runtime.
+# `geoip: true` (packages/browser/src/pool.ts) otherwise makes camoufox-js fetch
+# GeoLite2-City.mmdb from P3TERX/GeoLite.mmdb on first browser launch, into
+# $CAMOUFOX_INSTALL_DIR. An interrupted/truncated download leaves a corrupt file that
+# camoufox-js reuses forever (getGeolocation only re-downloads when the file is absent),
+# crashing every launch with "Invalid Extended Type at offset N val 7" (issue #20).
+# Baking a verified copy into the image makes startup deterministic and removes the
+# runtime GitHub dependency + first-launch download latency. The size check fails the
+# build if the download is truncated, so a corrupt file can never be baked in.
+RUN curl -fsSL \
+      "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-City.mmdb" \
+      -o /opt/camoufox/GeoLite2-City.mmdb && \
+    [ "$(stat -c%s /opt/camoufox/GeoLite2-City.mmdb)" -gt 10000000 ] || \
+      { echo "GeoLite2-City.mmdb download too small / failed"; exit 1; }
+
 # ── Stage 3: lean runtime (only API-required files) ────────────────────────────
 # debian:bookworm-slim replaces ubuntu:22.04 — same glibc family, ~50 MB smaller base.
 # Camoufox/Firefox require glibc; Alpine's musl is incompatible.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -92,6 +92,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libasound2 \
       fonts-liberation \
       ca-certificates \
+      curl \
     && apt-get clean
 
 COPY --from=oven/bun:1.3.14  /usr/local/bin/bun /usr/local/bin/bun

--- a/apps/api/Dockerfile.baseline
+++ b/apps/api/Dockerfile.baseline
@@ -64,6 +64,21 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     chmod -R 755 /opt/camoufox && \
     rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
 
+# Bake the GeoIP database so camoufox-js never downloads it at runtime.
+# `geoip: true` (packages/browser/src/pool.ts) otherwise makes camoufox-js fetch
+# GeoLite2-City.mmdb from P3TERX/GeoLite.mmdb on first browser launch, into
+# $CAMOUFOX_INSTALL_DIR. An interrupted/truncated download leaves a corrupt file that
+# camoufox-js reuses forever (getGeolocation only re-downloads when the file is absent),
+# crashing every launch with "Invalid Extended Type at offset N val 7" (issue #20).
+# Baking a verified copy into the image makes startup deterministic and removes the
+# runtime GitHub dependency + first-launch download latency. The size check fails the
+# build if the download is truncated, so a corrupt file can never be baked in.
+RUN curl -fsSL \
+      "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-City.mmdb" \
+      -o /opt/camoufox/GeoLite2-City.mmdb && \
+    [ "$(stat -c%s /opt/camoufox/GeoLite2-City.mmdb)" -gt 10000000 ] || \
+      { echo "GeoLite2-City.mmdb download too small / failed"; exit 1; }
+
 # ── Stage 3: lean runtime (only API-required files) ────────────────────────────
 # debian:bookworm-slim replaces ubuntu:22.04 — same glibc family, ~50 MB smaller base.
 # Camoufox/Firefox require glibc; Alpine's musl is incompatible.

--- a/apps/web/app/components/CompareTable.vue
+++ b/apps/web/app/components/CompareTable.vue
@@ -59,7 +59,7 @@ const rows = [
   },
   { feature: "Adaptive tier execution", trawl: "✓ 4 tiers", flaresolver: "✗ always browser", byparr: "~" },
   { feature: "Browser engine", trawl: "✓ Camoufox Firefox", flaresolver: "✗ Chrome", byparr: "✓ Camoufox Firefox" },
-  { feature: "Docker image size", trawl: "✓ 1.04 GB", flaresolver: "✓ 1.03 GB", byparr: "✗ 4.10 GB" },
+  { feature: "Docker image size", trawl: "✓ 1.14 GB", flaresolver: "✓ 1.03 GB", byparr: "✗ 4.10 GB" },
   { feature: "Memory footprint (peak)", trawl: "✓ 770 MB", flaresolver: "✗ 500 MB", byparr: "✗ 1.35 GB" },
   { feature: "Cloudflare challenge speed", trawl: "✓ 4–15s", flaresolver: "✗ 11–18s", byparr: "✗ 13–18s" },
   { feature: "CF Turnstile solving", trawl: "✓ shadow DOM click", flaresolver: "✗", byparr: "✗" },


### PR DESCRIPTION
## Summary

Fixes the TRAWL container being marked `unhealthy` and an intermittent `Invalid Extended Type at offset 0 val 7` startup crash. Restores `curl` to the API runtime image (the healthcheck depends on it) and bakes the GeoLite2 DB into the image so it's no longer downloaded at runtime, where an interrupted download could leave a corrupt file that Camoufox reused on every launch.

## Linked issues

Closes #20

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [ ] I added or updated tests for the behavior change (if applicable)
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).