### PR TITLE
Add Akamai Bot Manager (behavioral / sec-cpt) challenge support

### DIFF
--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -1,6 +1,13 @@
 import { FINGERPRINT } from "@trawl/browser"
 import type { TierResult } from "@trawl/types"
-import { hasHcaptcha, hasRecaptcha, hasTurnstile, isBlocked, isCloudflarePage } from "../utils/detect"
+import {
+  hasAkamaiChallenge,
+  hasHcaptcha,
+  hasRecaptcha,
+  hasTurnstile,
+  isBlocked,
+  isCloudflarePage,
+} from "../utils/detect"
 import { normalizeHtml } from "../utils/html"
 
 export interface Tier1Result extends TierResult {
@@ -55,6 +62,11 @@ export async function runTier1(
     }
     if (hasTurnstile(html)) {
       return { tier: 1, status: "needs-js", durationMs: Date.now() - start, reason: "turnstile-shell" }
+    }
+    // Akamai's behavioral interstitial is served with HTTP 200; escalate to a browser
+    // tier so the sensor JS runs and akamaiWait can drive the challenge.
+    if (hasAkamaiChallenge(html, headers)) {
+      return { tier: 1, status: "needs-js", durationMs: Date.now() - start, reason: "akamai-interstitial" }
     }
 
     if (isBlocked(res.status, html)) {

--- a/packages/tiers/src/tiers/2.ts
+++ b/packages/tiers/src/tiers/2.ts
@@ -2,7 +2,7 @@ import type { BrowserHandle } from "@trawl/browser"
 import type { Cookie, SessionData, TierResult } from "@trawl/types"
 import { solvePageCaptchas } from "../solvers"
 import { normalizeSameSite, toCookies } from "../utils/cookies"
-import { isBlocked, isBrowserErrorPage, isCloudflarePage } from "../utils/detect"
+import { hasAkamaiChallenge, isBlocked, isBrowserErrorPage, isCloudflarePage } from "../utils/detect"
 import { normalizeHtml } from "../utils/html"
 import type { RouteLike } from "../utils/sanitize"
 import { routeContinueOverrides } from "../utils/sanitize"
@@ -73,6 +73,12 @@ export async function runTier2(
 
     if (isCloudflarePage(html, {})) {
       return { tier: 2, status: "blocked", durationMs: Date.now() - start, reason: "session-expired" }
+    }
+
+    // A cached session that lands back on Akamai's interstitial is stale — force a
+    // fresh Tier-3 solve rather than returning the ~2KB challenge stub as content.
+    if (hasAkamaiChallenge(html)) {
+      return { tier: 2, status: "blocked", durationMs: Date.now() - start, reason: "akamai-session-expired" }
     }
 
     if (isBlocked(statusCode, html)) {

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -2,10 +2,12 @@ import type { BrowserHandle } from "@trawl/browser"
 import { FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
 import { solvePageCaptchas } from "../solvers"
+import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
 import {
   detectChallengeType,
+  hasAkamaiChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -84,7 +86,9 @@ export async function runTier3(
     const resolution =
       challengeType === "imperva"
         ? await waitForImpervaResolution(page, remaining, url)
-        : await waitForChallengeResolution(page, remaining, url)
+        : challengeType === "akamai"
+          ? await waitForAkamaiResolution(page, remaining, url)
+          : await waitForChallengeResolution(page, remaining, url)
 
     if (resolution !== "ok") {
       return {
@@ -96,9 +100,7 @@ export async function runTier3(
             ? challengeType === "imperva"
               ? "datacenter-ip-blocked (imperva sensor cookie obtained but challenge persisted — needs residential proxy)"
               : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
-            : challengeType === "imperva"
-              ? "imperva-challenge-timeout"
-              : "cloudflare-challenge-timeout",
+            : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
     }
 
@@ -146,6 +148,13 @@ export async function runTier3(
       const pageUrl = page.url()
       console.log(`[tier3] imperva-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
       return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "imperva-persistent" }
+    }
+
+    if (hasAkamaiChallenge(html)) {
+      const pageTitle = await page.title().catch(() => "?")
+      const pageUrl = page.url()
+      console.log(`[tier3] akamai-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
+      return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "akamai-persistent" }
     }
 
     if (isBlocked(statusCode, html)) {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -2,10 +2,12 @@ import type { BrowserHandle } from "@trawl/browser"
 import { FINGERPRINT } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
 import { solvePageCaptchas } from "../solvers"
+import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
 import {
   detectChallengeType,
+  hasAkamaiChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -102,7 +104,9 @@ export async function runTier4(
     const resolution =
       challengeType === "imperva"
         ? await waitForImpervaResolution(page, remaining, url)
-        : await waitForChallengeResolution(page, remaining, url)
+        : challengeType === "akamai"
+          ? await waitForAkamaiResolution(page, remaining, url)
+          : await waitForChallengeResolution(page, remaining, url)
 
     if (resolution !== "ok") {
       return {
@@ -112,9 +116,7 @@ export async function runTier4(
         reason:
           resolution === "ip-blocked"
             ? "proxy-ip-blocked"
-            : challengeType === "imperva"
-              ? "imperva-challenge-timeout"
-              : "cloudflare-challenge-timeout",
+            : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
     }
 
@@ -159,6 +161,15 @@ export async function runTier4(
         status: "blocked",
         durationMs: Date.now() - start,
         reason: "imperva-persistent",
+      }
+    }
+
+    if (hasAkamaiChallenge(html)) {
+      return {
+        tier: 4,
+        status: "blocked",
+        durationMs: Date.now() - start,
+        reason: "akamai-persistent",
       }
     }
 

--- a/packages/tiers/src/utils/akamaiWait.ts
+++ b/packages/tiers/src/utils/akamaiWait.ts
@@ -1,0 +1,133 @@
+// Akamai Bot Manager "Behavioral Detection" (sec-cpt / SBSD) resolver — the Akamai
+// analogue of challengeWait.ts (Cloudflare) and impervaWait.ts (Imperva).
+//
+// Akamai's interstitial is a hidden #sec-if-cpt-container ("behavioral-content")
+// driven by an obfuscated sensor script. The sensor collects pointer/timing telemetry
+// and POSTs it; an inline hook then location.reload()s into the real page. Some
+// variants also surface a press-and-hold "progress button" that must be actuated.
+//
+// Unlike CF/Imperva (which resolve from JS execution + a cookie alone), Akamai's
+// behavioral challenge scores *interaction*, so we drive human-like mouse motion and,
+// if the hold button becomes visible, press-and-hold it — then wait for the reload.
+//
+// Known risk: Akamai's behavioral scoring is adversarial to synthetic input; success
+// is not guaranteed even from a real browser. Camoufox emits genuine Firefox-level
+// pointer events (not CDP synthetic ones), which is the best available shot.
+
+import type { Page } from "patchright"
+import { hasAkamaiChallenge } from "./detect"
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export async function waitForAkamaiResolution(
+  page: Page,
+  timeoutMs: number,
+  originalUrl?: string,
+): Promise<"ok" | "ip-blocked" | "timeout"> {
+  const deadline = Date.now() + Math.max(timeoutMs, 35_000)
+
+  const early = await page.content().catch(() => "")
+  if (early && !hasAkamaiChallenge(early)) {
+    await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {})
+    return "ok"
+  }
+
+  // Let the sensor script boot and start listening for behavioral telemetry.
+  await sleep(1500)
+  await wanderMouse(page, 8)
+
+  let heldOnce = false
+  let navigatedOnce = false
+  const sawCookieAt: { t: number | null } = { t: null }
+
+  while (Date.now() < deadline) {
+    const html = await page.content().catch(() => "")
+    if (html && !hasAkamaiChallenge(html) && html.length > 3500) {
+      await page.waitForLoadState("load", { timeout: 5000 }).catch(() => {})
+      return "ok"
+    }
+
+    // Once Akamai has set its clearance cookie but the reload hasn't fired, give it a
+    // grace period then navigate to the original URL ourselves (mirrors CF/Imperva).
+    const hasAbck = await pageHasAkamaiCookie(page)
+    if (hasAbck && sawCookieAt.t === null) {
+      sawCookieAt.t = Date.now()
+      console.log("[akamai] _abck cookie present")
+    }
+    if (hasAbck && !navigatedOnce && originalUrl && sawCookieAt.t && Date.now() - sawCookieAt.t > 6000) {
+      navigatedOnce = true
+      console.log("[akamai] cookie set but still on interstitial — navigating to original URL")
+      await page.goto(originalUrl, { waitUntil: "domcontentloaded", timeout: 15_000 }).catch(() => {})
+      await page.waitForLoadState("networkidle", { timeout: 8_000 }).catch(() => {})
+      continue
+    }
+
+    // If the behavioral widget surfaced a press-and-hold button, actuate it once.
+    if (!heldOnce) {
+      heldOnce = await pressAndHold(page).catch(() => false)
+    }
+
+    await wanderMouse(page, 3)
+    await sleep(600)
+  }
+
+  return "timeout"
+}
+
+async function pageHasAkamaiCookie(page: Page): Promise<boolean> {
+  const cookies: Array<{ name: string; value: string }> = await page
+    .context()
+    .cookies()
+    .catch(() => [])
+  // A validated _abck has its 2nd '~'-segment != "-1"; presence + validation both help.
+  const abck = cookies.find((c) => c.name === "_abck")
+  if (!abck) return false
+  const seg = abck.value.split("~")[1]
+  return seg !== undefined && seg !== "-1"
+}
+
+// Move the pointer along a wandering path to produce plausible behavioral telemetry.
+async function wanderMouse(page: Page, points: number): Promise<void> {
+  try {
+    const vp = page.viewportSize() || { width: 1280, height: 800 }
+    let x = Math.random() * vp.width
+    let y = Math.random() * vp.height
+    for (let i = 0; i < points; i++) {
+      const nx = Math.max(2, Math.min(vp.width - 2, x + (Math.random() - 0.5) * vp.width * 0.5))
+      const ny = Math.max(2, Math.min(vp.height - 2, y + (Math.random() - 0.5) * vp.height * 0.5))
+      await page.mouse.move(nx, ny, { steps: 4 + Math.floor(Math.random() * 8) })
+      x = nx
+      y = ny
+      await sleep(60 + Math.random() * 140)
+    }
+  } catch {
+    // page navigating / closed — ignore
+  }
+}
+
+// Press-and-hold the behavioral "progress button" if the sensor has made it visible.
+async function pressAndHold(page: Page): Promise<boolean> {
+  const sel = "#progress-button, .behavioral-button, #sec-if-cpt-container [role='button']"
+  try {
+    const el = page.locator(sel).first()
+    if (!(await el.isVisible({ timeout: 500 }).catch(() => false))) return false
+    const box = await el.boundingBox().catch(() => null)
+    if (!box || box.width < 4 || box.height < 4) return false
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.mouse.move(cx - 18, cy - 10, { steps: 6 })
+    await page.mouse.move(cx, cy, { steps: 8 })
+    await page.mouse.down()
+    // Hold ~5.5s with micro-jitter so the "progress" bar fills.
+    const holdUntil = Date.now() + 5500
+    while (Date.now() < holdUntil) {
+      await page.mouse.move(cx + (Math.random() - 0.5) * 3, cy + (Math.random() - 0.5) * 3, { steps: 2 })
+      await sleep(220)
+    }
+    await page.mouse.up()
+    console.log("[akamai] press-and-hold performed")
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -5,6 +5,7 @@ export type ChallengeType =
   | "recaptcha"
   | "cap"
   | "imperva"
+  | "akamai"
   | "none"
 
 export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
@@ -83,10 +84,28 @@ export function hasImpervaChallenge(html: string, headers: Record<string, string
   return false
 }
 
+// Akamai Bot Manager "Behavioral Detection" (sec-cpt / SBSD) interstitial. Akamai
+// serves a near-empty page whose only real content is a hidden #sec-if-cpt-container
+// (the "behavioral-content" widget, often a press-and-hold button) plus an obfuscated
+// sensor script; once the sensor's XHR posts telemetry the page location.reload()s
+// into the real content. trawl solves this by driving human-like interaction and
+// waiting for the reload — see akamaiWait.ts. These DOM markers are challenge-only
+// (the class/id names don't appear on ordinary Akamai-fronted pages), so no size gate
+// is needed for them; the sensor-bootstrap fallback IS size-gated to avoid flagging
+// full pages that merely carry passive Akamai telemetry.
+export function hasAkamaiChallenge(html: string, _headers: Record<string, string> = {}): boolean {
+  if (/id=["']?sec-if-cpt-container|class=["'][^"']*behavioral-content|sec-bc-tile|scf-akamai-logo/i.test(html))
+    return true
+  if (/\/_sec\/(cp_challenge|verify)\//i.test(html)) return true
+  if (html.length < 3500 && /akamai\.com/i.test(html) && /(progress-button|behavioral|sec-cpt)/i.test(html)) return true
+  return false
+}
+
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
   if (hasTurnstile(html)) return "cloudflare-turnstile"
   if (isCloudflarePage(html, headers)) return "cloudflare-interstitial"
   if (hasImpervaChallenge(html, headers)) return "imperva"
+  if (hasAkamaiChallenge(html, headers)) return "akamai"
   if (hasHcaptcha(html)) return "hcaptcha"
   if (hasRecaptcha(html)) return "recaptcha"
   if (hasCapChallenge(html)) return "cap"
@@ -98,9 +117,10 @@ export function isBlocked(status: number, html: string): boolean {
   if (status === 202 || status === 403 || status === 429) return true
   if (isCloudflarePage(html, {})) return true
   if (hasImpervaChallenge(html)) return true
+  if (hasAkamaiChallenge(html)) return true
   return false
 }
 
 export function needsJs(html: string, headers: Record<string, string>): boolean {
-  return isCloudflarePage(html, headers) || hasImpervaChallenge(html, headers)
+  return isCloudflarePage(html, headers) || hasImpervaChallenge(html, headers) || hasAkamaiChallenge(html, headers)
 }


### PR DESCRIPTION
While running trawl against real used-car inventory sites, I hit a class of target that came back as a `200` "success" but whose `html` was only ~2 KB — and that 2 KB was Akamai Bot Manager's behavioral interstitial, not the page. trawl natively solves Cloudflare and Imperva but had no notion of Akamai, so its tier detection treated the interstitial as a normal load and returned the stub as content. This PR adds Akamai support alongside the existing CF/Imperva handling.

**How you know you're hitting this from the response:** `/scrape` returns `status: "success"` with `statusCode: 200` but a tiny (~2 KB) `html` whose body is just `<div id="sec-if-cpt-container" ...>` + "Powered and protected by Akamai" — a success-looking response that carries the challenge widget instead of real content.

**Test site:** Edmunds fronts its inventory SRP with Akamai — e.g. `https://www.edmunds.com/inventory/srp.html?inventorytype=used%2Ccpo&make=porsche&model=porsche%7Cmacan`. Before this change a fetch returns the ~2 KB `sec-if-cpt-container` stub; after it, trawl resolves the challenge and returns the real ~130 KB+ page.

**1. Detect the Akamai behavioral interstitial**

`detect.ts` gains `hasAkamaiChallenge()` and an `"akamai"` `ChallengeType`. It keys on Akamai's challenge-only DOM (`sec-if-cpt-container`, `behavioral-content`, `scf-akamai-logo`) — class/id names that appear on the interstitial but not on ordinary Akamai-fronted pages — plus a size-gated fallback for the sensor bootstrap (same caution you applied to the lean CF stub in #19: the marker alone isn't exclusive to a challenge, so gate on page size). Wired into `detectChallengeType`, `isBlocked`, and `needsJs`.

**2. Resolve it**

New `akamaiWait.ts`, the Akamai analogue of `challengeWait.ts` / `impervaWait.ts`. Akamai's `sec-cpt` challenge differs from CF/Imperva in one important way: it scores *interaction*, not just JS execution + a cookie. The sensor collects pointer/timing telemetry, POSTs it, and only then `location.reload()`s into the real page (some variants surface a press-and-hold "progress button"). So the resolver drives human-like mouse motion, presses-and-holds the behavioral button if it becomes visible, watches for the `_abck` cookie, and waits for the reload into real content — self-navigating to the original URL if the reload stalls, exactly like the CF/Imperva waiters do.

**3. Wire it through the tiers**

Tier 1 escalates the 200 interstitial as `needs-js`; tier 2 treats a cached session that lands back on the interstitial as stale (`akamai-session-expired`) so it forces a fresh solve; tiers 3 & 4 dispatch `waitForAkamaiResolution` and report `akamai-persistent` if it doesn't clear — so it flags the pool for recycle and escalates to the residential-proxy tier, same as CF/Imperva.

**Caveat (same spirit as the Imperva note):** Akamai's behavioral scoring is adversarial to synthetic input, so success isn't guaranteed on every Akamai deployment — it works on the sites I tested (Edmunds), and Camoufox's genuine Firefox-level pointer events (not CDP-synthetic) give it the best shot. It degrades safely: if the challenge doesn't clear, the tier reports `akamai-persistent` / `timeout` rather than returning the stub as a false success.

All additive — no existing fields or types changed shape, and the Cloudflare/Imperva paths are untouched (regression-checked against a Cloudflare-fronted site and an embedded-JSON site). Rebuilt and smoke-tested the image.
