### PR TITLE
fix(tiers): return full body from Tier 1, not the 4 KiB detection preview

### DIFF
--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -150,11 +150,13 @@ export async function runTier1(
       durationMs: Date.now() - start,
       // `html` is best-effort text view of the body — only meaningful for text-like
       // content-types. Empty for binary payloads so /scrape consumers see the body
-      // is binary via the contentType field. Decode the full byte buffer here —
-      // `previewText` is bounded to 4 KiB for challenge detection and must not be
-      // used as the response body.
+      // is binary via the contentType field. `previewText` is bounded to 4 KiB for
+      // challenge detection and must not be used as the response body — decode the
+      // full buffer, reusing the preview only when it already covers the whole body.
       html: isTextContentType(contentType)
-        ? normalizeHtml(new TextDecoder("utf-8", { fatal: false }).decode(rawBytes))
+        ? normalizeHtml(
+            rawBytes.length > previewLen ? new TextDecoder("utf-8", { fatal: false }).decode(rawBytes) : previewText,
+          )
         : "",
       body: rawBytes,
       responseHeaders,

--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -150,8 +150,12 @@ export async function runTier1(
       durationMs: Date.now() - start,
       // `html` is best-effort text view of the body — only meaningful for text-like
       // content-types. Empty for binary payloads so /scrape consumers see the body
-      // is binary via the contentType field.
-      html: isTextContentType(contentType) ? normalizeHtml(previewText) : "",
+      // is binary via the contentType field. Decode the full byte buffer here —
+      // `previewText` is bounded to 4 KiB for challenge detection and must not be
+      // used as the response body.
+      html: isTextContentType(contentType)
+        ? normalizeHtml(new TextDecoder("utf-8", { fatal: false }).decode(rawBytes))
+        : "",
       body: rawBytes,
       responseHeaders,
       contentType,

--- a/packages/tiers/tests/runTier1FullBody.test.ts
+++ b/packages/tiers/tests/runTier1FullBody.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { runTier1 } from "../src/tiers/1"
+
+const installFetchMock = (responder: () => Response) => {
+  const originalFetch = globalThis.fetch
+  ;(globalThis as { fetch: typeof fetch }).fetch = (async () => responder()) as typeof fetch
+  return () => {
+    ;(globalThis as { fetch: typeof fetch }).fetch = originalFetch
+  }
+}
+
+const htmlResponse = (html: string) =>
+  new Response(html, {
+    status: 200,
+    headers: { "content-type": "text/html" },
+  })
+
+describe("runTier1 — full body on success (regression #46)", () => {
+  test("returns the complete html for text responses larger than the 4 KiB detection preview", async () => {
+    // Only closing marker sits at the very end, far past the preview window —
+    // a truncated body cannot contain it.
+    const filler = `<p>${"x".repeat(100)}</p>\n`.repeat(300)
+    const html = `<html><body>${filler}<div id="the-end">done</div></body></html>`
+    expect(html.length).toBeGreaterThan(4096 * 2)
+    const restore = installFetchMock(() => htmlResponse(html))
+    try {
+      const result = await runTier1("https://example.com/large")
+      expect(result.status).toBe("success")
+      expect(result.html).toBe(html)
+      expect(new TextDecoder().decode(result.body)).toBe(html)
+    } finally {
+      restore()
+    }
+  })
+
+  test("a multi-byte character straddling the preview boundary decodes intact", async () => {
+    // '€' is 3 bytes in UTF-8 and starts at byte 4095, so the bounded preview
+    // cuts it mid-sequence (this is why #46 saw cuts at 4093-4096, not always
+    // exactly 4096). The success body must decode from the full buffer and
+    // keep the character intact.
+    const html = `${"a".repeat(4095)}€ tail beyond the preview window`
+    const restore = installFetchMock(() => htmlResponse(html))
+    try {
+      const result = await runTier1("https://example.com/boundary")
+      expect(result.status).toBe("success")
+      expect(result.html).toBe(html)
+      expect(result.html).toContain("€ tail")
+    } finally {
+      restore()
+    }
+  })
+
+  test("responses that fit inside the preview window are returned unchanged", async () => {
+    const html = "<html><body>small</body></html>"
+    const restore = installFetchMock(() => htmlResponse(html))
+    try {
+      const result = await runTier1("https://example.com/small")
+      expect(result.status).toBe("success")
+      expect(result.html).toBe(html)
+    } finally {
+      restore()
+    }
+  })
+})


### PR DESCRIPTION
Fixes #46

## Root cause

d1ebbdd (`feat(tiers): preserve raw response payloads`, shipped in 1.2.0) introduced a bounded 4096-byte `previewText` in `runTier1`, decoded from the head of the body for challenge detection — and then reused it as the `html` field of the success result:

```ts
const previewLen = Math.min(rawBytes.length, 4096)
const previewText = new TextDecoder("utf-8", { fatal: false }).decode(rawBytes.subarray(0, previewLen))
...
html: isTextContentType(contentType) ? normalizeHtml(previewText) : "",
```

Both `/v1` (`solution.response`) and `/scrape` serve `result.html`, so any text response over 4 KiB that succeeds at Tier 1 (i.e. no challenge, the common case for unprotected or currently-unchallenged sites) is silently truncated to a byte-exact 4 KiB prefix — HTTP 200, `status: "ok"`, nothing indicating the loss. That matches every observation in #46, including the not-always-exactly-4096 cut (multi-byte UTF-8 sequences straddling the boundary are replaced, shifting the decoded length slightly).

Tiers 2–4 are unaffected — their `html` is the browser-rendered DOM, not the preview.

## Fix

Decode the full `rawBytes` buffer (which Tier 1 already fetches and returns as `body`) for `html`. `previewText` stays bounded and is still used only for challenge/block detection, preserving the intent of d1ebbdd.

## Verification

- Reproduced #46 against a deployed 1.2.0 instance before the fix: `request.get` on the Wikipedia main page via `/v1` returned `solution.response` of exactly 4096 chars; a 570 KB forum page came back as a 4 KB prefix with zero links.
- `npx tsc --noEmit` in `packages/tiers` passes.
- `biome check` on the changed file passes.

I don't have an AVX2-capable spare host to run the full container E2E, but the change only substitutes which already-fetched buffer gets decoded; the reporter of #46 offered to test against their three repro URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)