### PR TITLE
fix: report effective URL after redirects

### DIFF
--- a/apps/docs/api-reference/native-api.md
+++ b/apps/docs/api-reference/native-api.md
@@ -37,7 +37,7 @@ interface ScrapeRequest {
 
 ```typescript
 interface ScrapeResult {
-  url: string
+  url: string                  // final URL after redirects
   html: string
   cookies: Cookie[]
   userAgent: string

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -81,7 +81,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
       // UA from the pool so even Tier 1 requests don't share a single signature.
       const tier1UA = FINGERPRINT_POOL[Math.floor(Math.random() * FINGERPRINT_POOL.length)].userAgent
       return {
-        url: req.url,
+        url: t1.effectiveUrl ?? req.url,
         html: normalizeHtml(t1.html ?? ""),
         cookies: [],
         userAgent: tier1UA,
@@ -123,7 +123,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
           })
         }
         return {
-          url: req.url,
+          url: t2.effectiveUrl ?? req.url,
           html: normalizeHtml(t2.html ?? ""),
           cookies: t2.cookies ?? [],
           userAgent: session.userAgent,
@@ -187,7 +187,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
         })
       }
       return {
-        url: req.url,
+        url: t3.effectiveUrl ?? req.url,
         html: normalizeHtml(t3.html ?? ""),
         cookies,
         userAgent: t3.userAgent ?? FINGERPRINT.userAgent,
@@ -249,7 +249,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
         })
       }
       return {
-        url: req.url,
+        url: t4.effectiveUrl ?? req.url,
         html: normalizeHtml(t4.html ?? ""),
         cookies,
         userAgent: t4.userAgent ?? FINGERPRINT.userAgent,

--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -13,6 +13,7 @@ import { isTextContentType } from "../utils/response"
 
 export interface Tier1Result extends TierResult {
   tier: 1
+  effectiveUrl?: string
   html?: string
   body?: Uint8Array
   responseHeaders?: Record<string, string>
@@ -148,6 +149,7 @@ export async function runTier1(
       tier: 1,
       status: "success",
       durationMs: Date.now() - start,
+      effectiveUrl: res.url,
       // `html` is best-effort text view of the body — only meaningful for text-like
       // content-types. Empty for binary payloads so /scrape consumers see the body
       // is binary via the contentType field. `previewText` is bounded to 4 KiB for

--- a/packages/tiers/src/tiers/2.ts
+++ b/packages/tiers/src/tiers/2.ts
@@ -10,6 +10,7 @@ import { routeContinueOverrides } from "../utils/sanitize"
 
 export interface Tier2Result extends TierResult {
   tier: 2
+  effectiveUrl?: string
   html?: string
   body?: Uint8Array
   responseHeaders?: Record<string, string>
@@ -113,6 +114,7 @@ export async function runTier2(
       tier: 2,
       status: "success",
       durationMs: Date.now() - start,
+      effectiveUrl: page.url(),
       // For HTML/text content-types, `html` is the rendered DOM. For binary, leave
       // empty so /scrape consumers know to use `body`/`contentType`.
       html: !captured.contentType || isTextContentType(captured.contentType) ? normalizeHtml(html) : "",

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -22,6 +22,7 @@ import { routeContinueOverrides } from "../utils/sanitize"
 
 export interface Tier3Result extends TierResult {
   tier: 3
+  effectiveUrl?: string
   html?: string
   body?: Uint8Array
   responseHeaders?: Record<string, string>
@@ -177,6 +178,7 @@ export async function runTier3(
       tier: 3,
       status: "success",
       durationMs: Date.now() - start,
+      effectiveUrl: page.url(),
       html: !captured.contentType || isTextContentType(captured.contentType) ? normalizeHtml(html) : "",
       ...captured,
       cookies,

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -22,6 +22,7 @@ import { routeContinueOverrides } from "../utils/sanitize"
 
 export interface Tier4Result extends TierResult {
   tier: 4
+  effectiveUrl?: string
   html?: string
   body?: Uint8Array
   responseHeaders?: Record<string, string>
@@ -170,6 +171,7 @@ export async function runTier4(
       tier: 4,
       status: "success",
       durationMs: Date.now() - start,
+      effectiveUrl: page.url(),
       html: !captured.contentType || isTextContentType(captured.contentType) ? normalizeHtml(html) : "",
       ...captured,
       cookies,

--- a/packages/tiers/tests/effectiveUrl.test.ts
+++ b/packages/tiers/tests/effectiveUrl.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import type { OrchestratorDeps } from "../src/orchestrator"
+import { scrape } from "../src/orchestrator"
+import { runTier1 } from "../src/tiers/1"
+
+const server = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url)
+    if (url.pathname === "/start") {
+      return Response.redirect(new URL("/final?ok=1", url), 302)
+    }
+    return new Response("<html><body>final response</body></html>", {
+      headers: { "Content-Type": "text/html" },
+    })
+  },
+})
+
+afterAll(() => server.stop(true))
+
+const baseUrl = `http://127.0.0.1:${server.port}`
+const unusedBrowserDeps: OrchestratorDeps = {
+  acquireBrowser: async () => {
+    throw new Error("Tier 1 success should not acquire a browser")
+  },
+  releaseBrowser: () => {},
+  loadSession: async () => undefined,
+  saveSession: async () => {},
+  invalidateSession: async () => {},
+}
+
+describe("effective URL reporting", () => {
+  test("Tier 1 and the orchestrator report the final URL after a redirect", async () => {
+    const requestedUrl = `${baseUrl}/start`
+    const finalUrl = `${baseUrl}/final?ok=1`
+
+    const tierResult = await runTier1(requestedUrl)
+    expect(tierResult.status).toBe("success")
+    expect(tierResult.effectiveUrl).toBe(finalUrl)
+
+    const result = await scrape({ url: requestedUrl }, unusedBrowserDeps)
+    expect(result.url).toBe(finalUrl)
+  })
+
+  test("a request without a redirect retains its requested URL", async () => {
+    const requestedUrl = `${baseUrl}/final?ok=1`
+
+    const result = await scrape({ url: requestedUrl }, unusedBrowserDeps)
+    expect(result.url).toBe(requestedUrl)
+  })
+})

--- a/packages/tiers/tests/runTier2.test.ts
+++ b/packages/tiers/tests/runTier2.test.ts
@@ -51,6 +51,7 @@ describe("runTier2", () => {
     let userAgent: Record<string, string> | undefined
     let pageClosed = false
     const page = {
+      url: () => "https://example.com/final?ok=1",
       setExtraHTTPHeaders: async (headers: Record<string, string>) => {
         userAgent = headers
       },
@@ -74,6 +75,7 @@ describe("runTier2", () => {
 
     expect(result.status).toBe("success")
     expect(result.html).toContain("pool context content")
+    expect(result.effectiveUrl).toBe("https://example.com/final?ok=1")
     expect(injectedCookies).toEqual(session.cookies)
     expect(userAgent).toEqual({ "User-Agent": session.userAgent })
     expect(pageClosed).toBe(true)


### PR DESCRIPTION
## Summary

Fix URL reporting so successful scrape responses return the effective final URL after redirects. Tier 1 uses the final fetch response URL, while browser tiers report the page URL after navigation and challenge resolution.

## Linked issues

Closes #51 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## Testing

- Full Bun test suite: 157 passed
- TypeScript checks passed for all workspaces
- Non-rewriting Biome checks passed
- Added redirect and no-redirect coverage for Tier 1 and the orchestrator
- Extended Tier 2 coverage to verify the final browser URL

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).