### PR TITLE
fix(proxy): split Set-Cookie on newline in writeResponseFromBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Proxy: malformed `Set-Cookie` headers for Go and other strict HTTP/1.1 clients.** Playwright's `response.allHeaders()` joins multiple `Set-Cookie` values with `\n` into a single map entry. `writeResponseFromBuffer` was emitting that string as one header line with embedded newlines, which Go's `net/http` parser (and other strict clients) rejected as a malformed MIME header line — in particular when an `Expires` date containing a comma appeared after the fold. The fix splits on `\n` and emits each cookie as its own `Set-Cookie:` header line, as required by RFC 6265.
+
 ## [1.4.0] - 2026-08-10
 
 ### Changed

--- a/apps/api/src/proxy/__tests__/server.test.ts
+++ b/apps/api/src/proxy/__tests__/server.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { PassThrough } from "node:stream"
+import type net from "node:net"
+import { writeResponseFromBuffer } from "../server"
+
+describe("writeResponseFromBuffer — Set-Cookie newline folding", () => {
+  test("emits one Set-Cookie line per cookie when Playwright newline-folds them", () => {
+    // Playwright's response.allHeaders() joins multiple Set-Cookie values with \n.
+    // A bare value after the fold creates a 'malformed MIME header line' error in
+    // strict HTTP/1.1 clients (e.g. Go's net/http) when the Expires date contains
+    // a comma.
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    const cookieA = "session-id=abc; Domain=.example.com; Path=/; Secure"
+    const cookieB =
+      "session-id-time=123456789l; Domain=.example.com; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; Secure"
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": `${cookieA}\n${cookieB}`, "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+
+    // Must produce two separate header lines, not one line with an embedded newline.
+    expect(cookieLines).toHaveLength(2)
+    expect(cookieLines[0]).toContain("session-id=abc")
+    expect(cookieLines[1]).toContain("session-id-time=")
+
+    // No bare continuation line — the Expires comma must not produce a split.
+    const malformed = lines.filter((l) => /^session-id-time=/.test(l))
+    expect(malformed).toHaveLength(0)
+  })
+
+  test("passes through a single-value Set-Cookie header unchanged", () => {
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": "token=xyz; Path=/; HttpOnly", "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+    expect(cookieLines).toHaveLength(1)
+    expect(cookieLines[0]).toContain("token=xyz")
+  })
+})

--- a/apps/api/src/proxy/server.ts
+++ b/apps/api/src/proxy/server.ts
@@ -547,7 +547,8 @@ function writeResponse(sock: net.Socket, status: number, body: Buffer, contentTy
 }
 
 // Buffered responses preserve end-to-end headers and derive a fresh body length.
-function writeResponseFromBuffer(
+// Exported for unit tests only — not part of the public proxy API.
+export function writeResponseFromBuffer(
   sock: net.Socket,
   status: number,
   upstreamHeaders: Record<string, string>,
@@ -562,6 +563,14 @@ function writeResponseFromBuffer(
     if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower)) continue
     if (lower === "content-length") continue
     if (lower === "content-type") emittedContentType = true
+    // Playwright joins multiple Set-Cookie values with \n into one map entry.
+    // Emit each cookie as its own header line — RFC 6265 forbids comma-folding.
+    if (lower === "set-cookie") {
+      for (const cookie of value.split("\n")) {
+        if (cookie.trim()) headerLines.push(`${name}: ${cookie.trim()}`)
+      }
+      continue
+    }
     headerLines.push(`${name}: ${value}`)
   }
   if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)


### PR DESCRIPTION
## Problem

Playwright's `response.allHeaders()` API joins multiple `Set-Cookie` response headers with `\n` into a single map entry. `responseFromScrapeResult` passes this map directly into `writeResponseFromBuffer`, which emits the raw string as one header line. The result is HTTP like:

```
Set-Cookie: session-id=abc; Domain=.example.com\n
session-id-time=123l; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; Secure
```

HTTP/1.1 clients that validate header syntax — Go's `net/http`, Java's `HttpClient`, and others — reject the bare `session-id-time=...` line as a malformed MIME header and return a transport error. This affects any site that sets more than one cookie, which is essentially all of them.

Notably, cookie values containing a comma in the `Expires` date make this particularly visible because the bare value itself contains a comma, which some parsers try to split further.

## Fix

In `writeResponseFromBuffer`, split the `set-cookie` header value on `\n` and emit each cookie as its own `Set-Cookie:` header line. RFC 6265 §4.1.1 explicitly forbids comma-folding for `Set-Cookie`; only the per-line form is valid.

All other headers continue to pass through unchanged. The fix is backward-compatible: a single-value cookie (no `\n`) produces one line as before.

`writeResponseFromBuffer` is exported so it can be tested directly.

## Tests

`apps/api/src/proxy/__tests__/server.test.ts` — two cases using a `PassThrough` stream as a socket mock:
- multi-value cookie (Playwright-style `\n` fold) → two separate `Set-Cookie:` lines, no malformed bare line
- single-value cookie → unchanged, still one line