### PR TITLE
fix(proxy): split Set-Cookie on newline in writeResponseFromBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Proxy: malformed `Set-Cookie` headers for Go and other strict HTTP/1.1 clients.** Playwright's `response.allHeaders()` joins multiple `Set-Cookie` values with `\n` into a single map entry. `writeResponseFromBuffer` was emitting that string as one header line with embedded newlines, which Go's `net/http` parser (and other strict clients) rejected as a malformed MIME header line — in particular when an `Expires` date containing a comma appeared after the fold. The fix splits on `\n` and emits each cookie as its own `Set-Cookie:` header line, as required by RFC 6265.
+
 ## [1.4.0] - 2026-08-10
 
 ### Changed

--- a/apps/api/src/proxy/__tests__/server.test.ts
+++ b/apps/api/src/proxy/__tests__/server.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import type net from "node:net"
+import { PassThrough } from "node:stream"
+import { writeResponseFromBuffer } from "../httpResponse"
+
+describe("writeResponseFromBuffer — Set-Cookie newline folding", () => {
+  test("emits one Set-Cookie line per cookie when Playwright newline-folds them", () => {
+    // Playwright's response.allHeaders() joins multiple Set-Cookie values with \n.
+    // A bare value after the fold creates a 'malformed MIME header line' error in
+    // strict HTTP/1.1 clients (e.g. Go's net/http) when the Expires date contains
+    // a comma.
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    const cookieA = "session-id=abc; Domain=.example.com; Path=/; Secure"
+    const cookieB =
+      "session-id-time=123456789l; Domain=.example.com; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; Secure"
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": `${cookieA}\n${cookieB}`, "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+
+    // Must produce two separate header lines, not one line with an embedded newline.
+    expect(cookieLines).toHaveLength(2)
+    expect(cookieLines[0]).toContain("session-id=abc")
+    expect(cookieLines[1]).toContain("session-id-time=")
+
+    // No bare continuation line — the Expires comma must not produce a split.
+    const malformed = lines.filter((l) => /^session-id-time=/.test(l))
+    expect(malformed).toHaveLength(0)
+  })
+
+  test("passes through a single-value Set-Cookie header unchanged", () => {
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": "token=xyz; Path=/; HttpOnly", "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+    expect(cookieLines).toHaveLength(1)
+    expect(cookieLines[0]).toContain("token=xyz")
+  })
+})

--- a/apps/api/src/proxy/httpResponse.ts
+++ b/apps/api/src/proxy/httpResponse.ts
@@ -1,0 +1,114 @@
+// Lightweight HTTP/1.1 response serialization helpers.
+// Kept separate from server.ts so unit tests can import without loading
+// the proxy server's heavy dependency chain (browser pool, scrape tiers).
+
+import net from "node:net"
+
+// RFC 7230 §6.1 hop-by-hop headers — must stay in sync with packages/tiers/src/utils/sanitize.ts.
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+
+function reason(status: number): string {
+  const map: Record<number, string> = {
+    200: "OK",
+    403: "Forbidden",
+    404: "Not Found",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+  }
+  return map[status] ?? "OK"
+}
+
+export function writeResponse(
+  sock: net.Socket,
+  status: number,
+  body: Buffer,
+  contentType = "text/html; charset=utf-8",
+): void {
+  const head =
+    `HTTP/1.1 ${status} ${reason(status)}\r\n` +
+    `Content-Type: ${contentType}\r\n` +
+    `Content-Length: ${body.length}\r\n` +
+    "Connection: close\r\n\r\n"
+  sock.write(head)
+  sock.write(body)
+  sock.end()
+}
+
+// Buffered responses preserve end-to-end headers and derive a fresh body length.
+export function writeResponseFromBuffer(
+  sock: net.Socket,
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  body: Buffer,
+  fallbackContentType: string,
+): void {
+  const ct = upstreamHeaders["content-type"] ?? fallbackContentType
+  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
+  let emittedContentType = false
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const lower = name.toLowerCase()
+    if (HOP_BY_HOP.has(lower)) continue
+    if (lower === "content-length") continue
+    if (lower === "content-type") emittedContentType = true
+    // Playwright joins multiple Set-Cookie values with \n into one map entry.
+    // Emit each cookie as its own header line — RFC 6265 forbids comma-folding.
+    if (lower === "set-cookie") {
+      for (const cookie of value.split(/\r?\n/)) {
+        const trimmed = cookie.trim()
+        if (trimmed) headerLines.push(`${name}: ${trimmed}`)
+      }
+      continue
+    }
+    headerLines.push(`${name}: ${value}`)
+  }
+  if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)
+  headerLines.push(`Content-Length: ${body.length}`)
+  headerLines.push("Connection: close")
+  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  sock.write(body)
+  sock.end()
+}
+
+// Streamed responses retain upstream transfer framing.
+export function writeResponseFromStream(
+  sock: net.Socket,
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  upstreamSocket: net.Socket,
+  fallbackContentType: string,
+  requestBodyLength: number,
+  prefix?: Buffer,
+): void {
+  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
+  let emittedContentType = false
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const lower = name.toLowerCase()
+    // The streamed bytes retain upstream HTTP/1.1 chunk framing, so preserve
+    // Transfer-Encoding. Other hop-by-hop headers remain connection-local.
+    if (HOP_BY_HOP.has(lower) && lower !== "transfer-encoding") continue
+    if (lower === "content-type") emittedContentType = true
+    headerLines.push(`${name}: ${value}`)
+  }
+  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
+  if (requestBodyLength > 0) headerLines.push(`X-Forwarded-Body-Length: ${requestBodyLength}`)
+  headerLines.push("Connection: close")
+  // Write HTTP headers first, then prefix body bytes (which arrived in the same
+  // TCP segment as upstream's response headers), then pipe the rest of the body.
+  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  if (prefix?.length) sock.write(prefix)
+  upstreamSocket.pipe(sock)
+  sock.on("error", () => upstreamSocket.destroy())
+  upstreamSocket.on("error", () => sock.destroy())
+  upstreamSocket.on("end", () => sock.end())
+  upstreamSocket.on("close", () => sock.end())
+}

--- a/apps/api/src/proxy/server.ts
+++ b/apps/api/src/proxy/server.ts
@@ -10,6 +10,7 @@ import {
 import { MitmCa } from "./ca"
 import { ChallengeCache } from "./challengeCache"
 import { directForwardHttp, directForwardHttps, type ForwardResult } from "./directForward"
+import { writeResponse, writeResponseFromBuffer, writeResponseFromStream } from "./httpResponse"
 import { responseFromScrapeResult } from "./responsePolicy"
 
 // General forward proxy with browser-backed challenge escalation. HTTPS is
@@ -535,77 +536,6 @@ async function handlePlainHttp(clientSocket: net.Socket, first: Buffer, opts: Mi
   })
 }
 
-function writeResponse(sock: net.Socket, status: number, body: Buffer, contentType = "text/html; charset=utf-8"): void {
-  const head =
-    `HTTP/1.1 ${status} ${reason(status)}\r\n` +
-    `Content-Type: ${contentType}\r\n` +
-    `Content-Length: ${body.length}\r\n` +
-    "Connection: close\r\n\r\n"
-  sock.write(head)
-  sock.write(body)
-  sock.end()
-}
-
-// Buffered responses preserve end-to-end headers and derive a fresh body length.
-function writeResponseFromBuffer(
-  sock: net.Socket,
-  status: number,
-  upstreamHeaders: Record<string, string>,
-  body: Buffer,
-  fallbackContentType: string,
-): void {
-  const ct = upstreamHeaders["content-type"] ?? fallbackContentType
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower)) continue
-    if (lower === "content-length") continue
-    if (lower === "content-type") emittedContentType = true
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)
-  headerLines.push(`Content-Length: ${body.length}`)
-  headerLines.push("Connection: close")
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
-  sock.write(body)
-  sock.end()
-}
-
-// Streamed responses retain upstream transfer framing.
-function writeResponseFromStream(
-  sock: net.Socket,
-  status: number,
-  upstreamHeaders: Record<string, string>,
-  upstreamSocket: net.Socket,
-  fallbackContentType: string,
-  requestBodyLength: number,
-  prefix?: Buffer,
-): void {
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    // The streamed bytes retain upstream HTTP/1.1 chunk framing, so preserve
-    // Transfer-Encoding. Other hop-by-hop headers remain connection-local.
-    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower) && lower !== "transfer-encoding") continue
-    if (lower === "content-type") emittedContentType = true
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
-  if (requestBodyLength > 0) headerLines.push(`X-Forwarded-Body-Length: ${requestBodyLength}`)
-  headerLines.push("Connection: close")
-  // Write HTTP headers first, then prefix body bytes (which arrived in the same
-  // TCP segment as upstream's response headers), then pipe the rest of the body.
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
-  if (prefix?.length) sock.write(prefix)
-  upstreamSocket.pipe(sock)
-  sock.on("error", () => upstreamSocket.destroy())
-  upstreamSocket.on("error", () => sock.destroy())
-  upstreamSocket.on("end", () => sock.end())
-  upstreamSocket.on("close", () => sock.end())
-}
-
 function parseHeaders(lines: string[]): Record<string, string> {
   const out: Record<string, string> = {}
   for (const line of lines) {
@@ -613,15 +543,4 @@ function parseHeaders(lines: string[]): Record<string, string> {
     if (idx > 0) out[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim()
   }
   return out
-}
-
-function reason(status: number): string {
-  const map: Record<number, string> = {
-    200: "OK",
-    403: "Forbidden",
-    404: "Not Found",
-    500: "Internal Server Error",
-    502: "Bad Gateway",
-  }
-  return map[status] ?? "OK"
 }


### PR DESCRIPTION
## Summary

`writeResponseFromBuffer` emits Playwright's browser-tier response headers directly to the client socket. Playwright's `response.allHeaders()` API joins multiple `Set-Cookie` values with `\n` into a single map entry. The function was emitting that string as one header line with embedded newlines. Strict HTTP/1.1 parsers — in particular when an `Expires` date containing a comma appears after the fold — reject this as a malformed MIME header line. The fix splits on `\n` and emits each cookie as its own `Set-Cookie:` line, as required by RFC 6265.

## Linked issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [ ] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).