### PR TITLE
feat(detect): add AWS WAF challenge detection and proxy 202 escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **AWS WAF challenge detection in `detect.ts`.** `hasAwsWafChallenge()` recognises the AWS WAF JavaScript challenge page by its `awsWafCookieDomainList`, `gokuProps`, and `token.awswaf.com/challenge.js` markers. A new `"aws-waf"` variant is added to `ChallengeType` and `detectChallengeType()`, and `isChallengeWall()` now treats a 202 response with an empty body as a challenge wall — aligning it with the existing `isBlocked()` behaviour (which already notes "202 is used by some CDNs (e.g. IMDb) as a bot-gate"). Together these let the MITM proxy escalate to the browser tier for AWS WAF–protected sites.
+
 ## [1.4.0] - 2026-08-10
 
 ### Changed

--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -9,6 +9,7 @@ export {
   type ChallengeType,
   detectChallengeType,
   hasAkamaiChallenge,
+  hasAwsWafChallenge,
   hasHcaptcha,
   hasImpervaChallenge,
   hasRecaptcha,

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -6,6 +6,7 @@ export type ChallengeType =
   | "cap"
   | "imperva"
   | "akamai"
+  | "aws-waf"
   | "none"
 
 export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
@@ -108,6 +109,12 @@ export function hasAkamaiChallenge(html: string, _headers: Record<string, string
   return false
 }
 
+// AWS WAF JavaScript challenge — the interstitial page that loads challenge.js to
+// issue an aws-waf-token cookie before redirecting to the protected resource.
+export function hasAwsWafChallenge(html: string): boolean {
+  return /awsWafCookieDomainList|window\.gokuProps|token\.awswaf\.com\/[^"']*challenge\.js/i.test(html)
+}
+
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
   if (hasTurnstile(html)) return "cloudflare-turnstile"
   if (isCloudflarePage(html, headers)) return "cloudflare-interstitial"
@@ -116,6 +123,7 @@ export function detectChallengeType(html: string, headers: Record<string, string
   if (hasHcaptcha(html)) return "hcaptcha"
   if (hasRecaptcha(html)) return "recaptcha"
   if (hasCapChallenge(html)) return "cap"
+  if (hasAwsWafChallenge(html)) return "aws-waf"
   return "none"
 }
 
@@ -146,9 +154,12 @@ const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
 // checks are TRAWL-specific heuristics (CF's auto-resolving bootstrap and Imperva's
 // sensor cookie challenge can come at 200 with body < a few KB).
 export function isChallengeWall(status: number, bodyLength: number, challengeType: ChallengeType): boolean {
+  // AWS WAF returns 202 with an empty body as the JS-challenge gate; isBlocked() already
+  // handles 202, but isChallengeWall() is used independently in the MITM proxy path.
+  if (status === 202 && bodyLength === 0) return true
   if (challengeType === "none") return false
   if (status === 403 || status === 503) return true
-  if (challengeType === "akamai") return true
+  if (challengeType === "akamai" || challengeType === "aws-waf") return true
   const threshold = LEAN_BODY_THRESHOLDS[challengeType]
   if (threshold !== undefined && bodyLength < threshold) return true
   return false

--- a/packages/tiers/tests/awsWaf.test.ts
+++ b/packages/tiers/tests/awsWaf.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { detectChallengeType, hasAwsWafChallenge, isChallengeWall } from "../src/utils/detect"
+
+// Minimal AWS WAF JS-challenge page — the real page loads challenge.js from
+// token.awswaf.com and sets an aws-waf-token cookie before redirecting.
+const awsWafInterstitial = `
+  <!DOCTYPE html>
+  <html>
+    <head><title>Request unsuccessful</title></head>
+    <body>
+      <script>
+        window.awsWafCookieDomainList = ['example.com'];
+        window.gokuProps = {"key":"AQIDAHjcYu0fake","iv":"abc123==","context":"def456=="};
+      </script>
+      <script src="https://abc123.token.awswaf.com/abc123/challenge.js" defer></script>
+    </body>
+  </html>
+`
+
+describe("AWS WAF challenge detection", () => {
+  test("detects the JS-challenge interstitial by awsWafCookieDomainList", () => {
+    expect(hasAwsWafChallenge(awsWafInterstitial)).toBe(true)
+    expect(detectChallengeType(awsWafInterstitial)).toBe("aws-waf")
+  })
+
+  test("detects the interstitial by gokuProps alone", () => {
+    const html = `<html><body><script>window.gokuProps = {"key":"AQI"}</script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(true)
+  })
+
+  test("detects the interstitial by challenge.js script src", () => {
+    const html = `<html><body><script src="https://x.token.awswaf.com/x/challenge.js"></script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(true)
+  })
+
+  test("does not flag a full page that merely loads AWS resources", () => {
+    const html = `<html><body>${"real content ".repeat(400)}<script src="https://sdk.amazonaws.com/js/aws-sdk-2.0.0.min.js"></script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(false)
+    expect(detectChallengeType(html)).toBe("none")
+  })
+
+  test("treats an AWS WAF interstitial as a proxy challenge wall", () => {
+    expect(isChallengeWall(200, Buffer.byteLength(awsWafInterstitial), "aws-waf")).toBe(true)
+  })
+
+  test("treats a 202 response with empty body as a challenge wall regardless of type", () => {
+    // AWS WAF returns HTTP 202 with a 0-byte body as a bot-gate before the JS
+    // challenge page. isBlocked() already handles this for /scrape; isChallengeWall()
+    // now matches so the MITM proxy path escalates consistently.
+    expect(isChallengeWall(202, 0, "none")).toBe(true)
+  })
+
+  test("does not flag a non-empty 202 as a challenge wall", () => {
+    // A legitimate 202 Accepted with a response body must not be escalated.
+    expect(isChallengeWall(202, 512, "none")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds detection for the AWS WAF JavaScript challenge, which is served by a range of sites. AWS WAF returns either a near-empty 202 response (empty body, no challenge HTML) or a small page containing `awsWafCookieDomainList`, `gokuProps`, and a `token.awswaf.com/challenge.js` script tag that a plain HTTP client cannot execute.

Two related gaps are fixed:

1. **`hasAwsWafChallenge()`** — new detector for the challenge HTML markers; a new `"aws-waf"` variant is added to `ChallengeType` and wired into `detectChallengeType()`.
2. **`isChallengeWall()`** — adds a `status === 202 && bodyLength === 0` guard before the early-return on `challengeType === "none"`. This brings `isChallengeWall()` in line with `isBlocked()`, which already notes *"202 is used by some CDNs (e.g. IMDb) as a bot-gate"*. Without this guard the MITM proxy path returns the empty body to the client instead of escalating to a browser tier.

## Linked issues

n/a

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [ ] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).