### PR TITLE
fix(tiers): give DDoS-Guard its own detection and wait

### DIFF
--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -9,6 +9,7 @@ export {
   type ChallengeType,
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasHcaptcha,
   hasImpervaChallenge,
   hasRecaptcha,

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -5,9 +5,11 @@ import { solvePageCaptchas } from "../solvers"
 import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
+import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -91,7 +93,9 @@ export async function runTier3(
         ? await waitForImpervaResolution(page, remaining, url)
         : challengeType === "akamai"
           ? await waitForAkamaiResolution(page, remaining, url)
-          : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+          : challengeType === "ddos-guard"
+            ? await waitForDdosGuardResolution(page, remaining, url)
+            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
 
     if (resolution !== "ok") {
       return {
@@ -104,6 +108,8 @@ export async function runTier3(
               ? "datacenter-ip-blocked (imperva sensor cookie obtained but challenge persisted — needs residential proxy)"
               : challengeType === "akamai"
                 ? "datacenter-ip-blocked (Akamai sensor cookie obtained but challenge persisted — needs residential proxy)"
+                : challengeType === "ddos-guard"
+                  ? "datacenter-ip-blocked (DDoS-Guard clearance cookie obtained but challenge persisted — needs residential proxy)"
                 : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
             : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
@@ -160,6 +166,13 @@ export async function runTier3(
       const pageUrl = page.url()
       console.log(`[tier3] akamai-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
       return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "akamai-persistent" }
+    }
+
+    if (hasDdosGuardChallenge(html)) {
+      const pageTitle = await page.title().catch(() => "?")
+      const pageUrl = page.url()
+      console.log(`[tier3] ddos-guard-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
+      return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "ddos-guard-persistent" }
     }
 
     if (isBlocked(mainResponse.status, html)) {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -5,9 +5,11 @@ import { solvePageCaptchas } from "../solvers"
 import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
+import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -88,7 +90,9 @@ export async function runTier4(
         ? await waitForImpervaResolution(page, remaining, url)
         : challengeType === "akamai"
           ? await waitForAkamaiResolution(page, remaining, url)
-          : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+          : challengeType === "ddos-guard"
+            ? await waitForDdosGuardResolution(page, remaining, url)
+            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
 
     if (resolution !== "ok") {
       return {
@@ -153,6 +157,13 @@ export async function runTier4(
         durationMs: Date.now() - start,
         reason: "akamai-persistent",
       }
+    }
+
+    if (hasDdosGuardChallenge(html)) {
+      const pageTitle = await page.title().catch(() => "?")
+      const pageUrl = page.url()
+      console.log(`[tier4] ddos-guard-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
+      return { tier: 4, status: "blocked", durationMs: Date.now() - start, reason: "ddos-guard-persistent" }
     }
 
     if (isBlocked(mainResponse.status, html)) {

--- a/packages/tiers/src/utils/ddosGuardWait.ts
+++ b/packages/tiers/src/utils/ddosGuardWait.ts
@@ -1,0 +1,163 @@
+// DDoS-Guard JS-challenge wait — mirrors impervaWait.ts's cookie polling loop.
+// DDoS-Guard serves a ~900-byte interstitial that loads
+// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
+// says "Checking your browser before accessing", and reloads into the real content once
+// its script has set the __ddg* cookies. Like Imperva's sensor challenge, a real browser
+// running real JS satisfies it — there is no obfuscation to reimplement, so we just wait
+// for the interstitial to go away.
+//
+// Before this existed, DDoS-Guard was folded into isCloudflarePage() and handled by
+// waitForChallengeResolution(), which polls for cf_clearance and Cloudflare DOM markers
+// that a DDoS-Guard page never emits. That burned the entire timeout and then reported
+// the failure as "cloudflare-persistent".
+//
+// Known risk: DDoS-Guard also has a checkbox ("I am not a robot") variant on some sites.
+// This wait does not drive it — the JS-only interstitial is what Anna's Archive serves,
+// which is what this was written and validated against. A checkbox page will fall through
+// to "timeout" rather than being mis-reported as solved.
+
+import type { Page } from "patchright"
+import { hasDdosGuardChallenge } from "./detect"
+
+// Two retries is enough to tell a missed auto-reload from a wall that keeps coming
+// back. Beyond that the browser is being held for nothing.
+const MAX_RENAVIGATIONS = 2
+
+// page.content() / context.cookies() can hang rather than reject when the browser
+// transport wedges — .catch() does not bound that, and a hang here holds a pooled
+// browser past the deadline. This service has already been bitten by pool entries
+// pinned by unbounded awaits, so every Playwright call in the loop goes through here.
+function bounded<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    p.catch(() => fallback),
+    new Promise<T>((r) => setTimeout(() => r(fallback), ms)),
+  ])
+}
+
+export async function waitForDdosGuardResolution(
+  page: Page,
+  timeoutMs: number,
+  originalUrl?: string,
+): Promise<"ok" | "ip-blocked" | "timeout"> {
+  // Never exceed the caller's budget. impervaWait/akamaiWait use Math.max(timeoutMs,
+  // 30_000), which silently extends a tier past the time the request asked for and
+  // keeps a scarce pooled browser checked out while it does.
+  const deadline = Date.now() + timeoutMs
+  const remaining = () => deadline - Date.now()
+  // goto + networkidle + content read can add up to ~28s. Skipping the re-navigation
+  // when less than that remains is what actually keeps the wait inside timeoutMs;
+  // clamping each individual call below then handles the boundary case.
+  const RENAV_BUDGET_MS = 28_000
+  let clearanceCookieAt: number | undefined
+  let lastRenavAt = 0
+  let sawPersistentChallenge = false
+  let cookieNamesLogged = false
+  let renavCount = 0
+
+  const targetHost = (() => {
+    try {
+      return new URL(originalUrl ?? page.url()).hostname
+    } catch {
+      return ""
+    }
+  })()
+
+  const earlyHtml = await bounded(page.content(), 5_000, "")
+  if (earlyHtml && !hasDdosGuardChallenge(earlyHtml)) {
+    await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {})
+    return "ok"
+  }
+
+  // Let the challenge script boot before polling
+  await new Promise((r) => setTimeout(r, 1000))
+
+  while (Date.now() < deadline) {
+    try {
+      // The interstitial clearing is the authoritative signal, not the cookie: DDoS-Guard
+      // sets __ddg1_/__ddgid_ style markers on the challenge page itself, so a cookie
+      // alone does not mean solved. Cookies are only used to decide whether it is worth
+      // re-navigating below.
+      const html = await bounded(page.content(), 5_000, "")
+      if (html && !hasDdosGuardChallenge(html)) {
+        await page.waitForLoadState("load", { timeout: 5000 }).catch(() => {})
+        return "ok"
+      }
+
+      const cookies: Array<{ name: string; domain: string }> = await bounded(
+        page.context().cookies(),
+        5_000,
+        [] as Array<{ name: string; domain: string }>,
+      )
+      const onTargetHost = (c: { domain: string }) =>
+        targetHost &&
+        (c.domain === targetHost ||
+          c.domain === `.${targetHost}` ||
+          targetHost.endsWith(c.domain.replace(/^\./, "")))
+      // __ddg1_/__ddgid_/__ddgmark_ are set by the interstitial itself, so matching
+      // any __ddg* cookie says nothing about having passed. Only the post-challenge
+      // cookies count. Matching broadly here meant re-navigating ~5s in, which yanked
+      // the page away from the still-running challenge script and then graded the
+      // result "ip-blocked" — reproduced from a residential IP, where an actual IP
+      // block was not plausible.
+      // Safe to read a pre-existing cookie as evidence of THIS solve: tiers 3 and 4
+      // both run in a newFreshContext() with no carried-over cookie jar, so anything
+      // here was set during this navigation.
+      const hasClearanceCookie = cookies.some((c) => /^__ddg[25]_/.test(c.name) && onTargetHost(c))
+
+      if (cookieNamesLogged === false && cookies.length > 0) {
+        cookieNamesLogged = true
+        console.log(`[ddos-guard] cookies so far: ${cookies.map((c) => c.name).join(", ") || "(none)"}`)
+      }
+
+      if (hasClearanceCookie) {
+        if (clearanceCookieAt === undefined) {
+          clearanceCookieAt = Date.now()
+          console.log("[ddos-guard] clearance cookie obtained")
+        }
+
+        // Cookie set but still on the interstitial — the auto-reload does not always
+        // fire. Navigate ourselves after a grace period, same as the Imperva path.
+        // Unlike Imperva we do NOT conclude on the first re-navigation: DDoS-Guard
+        // re-challenges cheaply, and one persisting interstitial is not evidence of
+        // an IP block. Keep polling until the deadline and let the caller escalate.
+        if (
+          originalUrl &&
+          Date.now() - clearanceCookieAt > 8000 &&
+          Date.now() - lastRenavAt > 15_000 &&
+          renavCount < MAX_RENAVIGATIONS &&
+          remaining() > RENAV_BUDGET_MS
+        ) {
+          lastRenavAt = Date.now()
+          renavCount++
+          console.log(
+            `[ddos-guard] cookie set but still on challenge page — navigating to original URL (${renavCount}/${MAX_RENAVIGATIONS})`,
+          )
+          const clamp = (ms: number) => Math.max(500, Math.min(ms, remaining()))
+          await page.goto(originalUrl, { waitUntil: "domcontentloaded", timeout: clamp(15_000) }).catch(() => {})
+          await page.waitForLoadState("networkidle", { timeout: clamp(8_000) }).catch(() => {})
+          const html2 = await bounded(page.content(), clamp(5_000), "")
+          // `html2 &&` matters: a goto timeout or a crashed page yields "", which the
+          // detector reports as "no challenge". Without the guard a navigation failure
+          // returns "ok" and the tier hands back an empty document as a solved page.
+          if (html2 && !hasDdosGuardChallenge(html2)) return "ok"
+          if (html2) sawPersistentChallenge = true
+        }
+
+        // Full clearance cookie set, and the wall came straight back every time we
+        // retried. Nothing further here will change that — the site is rejecting the
+        // request on something other than the JS challenge — so give the browser back
+        // rather than sitting on it until the deadline.
+        if (sawPersistentChallenge && renavCount >= MAX_RENAVIGATIONS) return "ip-blocked"
+      }
+    } catch {
+      // Page is mid-navigation — keep polling
+    }
+
+    await new Promise((r) => setTimeout(r, 300))
+  }
+
+  // Distinguish "we passed the JS challenge but the wall stayed up" (a reputation
+  // signal worth escalating to a residential proxy) from "the challenge never
+  // completed at all" (a timeout).
+  return sawPersistentChallenge ? "ip-blocked" : "timeout"
+}

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -6,13 +6,29 @@ export type ChallengeType =
   | "cap"
   | "imperva"
   | "akamai"
+  | "ddos-guard"
   | "none"
 
-export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
+// Cloudflare's own declaration that it is serving a challenge. Authoritative, unlike
+// every other check here, so it outranks the DDoS-Guard markers wherever the two meet.
+export function hasCloudflareChallengeHeader(headers: Record<string, string> = {}): boolean {
   const cfMitigated = Object.entries(headers).find(([name]) => name.toLowerCase() === "cf-mitigated")?.[1]
-  if (cfMitigated?.toLowerCase() === "challenge") return true
-  if (/<title>[^<]*(just a moment|ddos-guard|please wait|checking|attention required)[^<]*<\/title>/i.test(html))
-    return true
+  return cfMitigated?.toLowerCase() === "challenge"
+}
+
+export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
+  if (hasCloudflareChallengeHeader(headers)) return true
+  // Otherwise DDoS-Guard wins over the generic copy-text heuristics below: its
+  // interstitial says "Checking your browser before accessing", which they also match.
+  // This is an early return rather than ordering inside detectChallengeType() because
+  // tiers 3/4 call isCloudflarePage() directly for their persistence check.
+  if (hasDdosGuardChallenge(html, headers)) return false
+  // "ddos-guard" deliberately absent: DDoS-Guard is its own WAF with its own solve
+  // path (see hasDdosGuardChallenge / ddosGuardWait.ts). Matching it here routed it
+  // into the Cloudflare interstitial flow, which waits on cf_clearance and CF DOM
+  // markers that a DDoS-Guard page never emits — so it burned the whole timeout and
+  // then reported "cloudflare-persistent".
+  if (/<title>[^<]*(just a moment|please wait|checking|attention required)[^<]*<\/title>/i.test(html)) return true
   if (/checking your browser/i.test(html)) return true
   if (/enable javascript and cookies to continue/i.test(html)) return true
   if (/verify you are human/i.test(html)) return true
@@ -26,8 +42,6 @@ export function isCloudflarePage(html: string, headers: Record<string, string>):
   if (/_cf_chl_opt/i.test(html)) return true
   if (/id=["']challenge-form["']/i.test(html)) return true
   if (/orchestrate\/chl_page/i.test(html)) return true
-  // DDoS-Guard
-  if (/ddos-guard\.net|\.ddos-guard\.net/i.test(html)) return true
   // CF firewall/WAF deny page (error 1020 and friends) — static "blocked" page, not a
   // solvable JS challenge, but still needs to be recognized as CF so the orchestrator
   // reports tier failure and escalates instead of returning the block page as content
@@ -108,8 +122,40 @@ export function hasAkamaiChallenge(html: string, _headers: Record<string, string
   return false
 }
 
+// DDoS-Guard JS interstitial. The wall is a ~900-byte page that loads
+// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
+// shows "Checking your browser before accessing", and reloads into the real content once
+// the script has set the __ddg* cookies. A real browser executing real JS satisfies it
+// without challenge-specific logic, so — like Imperva — we detect the page and wait for
+// the cookie (see ddosGuardWait.ts).
+//
+// Every marker below is challenge-specific: the js-challenge asset paths, the
+// interstitial's own DOM ids, and its check.js. Deliberately NOT matched:
+//
+//   - `Server: ddos-guard` — present on every response DDoS-Guard fronts. Verified on
+//     annas-archive.gl, where the successful 200 and the 403 interstitial carry the
+//     identical header, so keying on it grades real content as a wall forever.
+//   - a bare `ddos-guard.net` mention — any page may link the provider. Size-gating it
+//     is not a fix: the gate is arbitrary, counts UTF-16 units rather than bytes, and
+//     still says nothing about the page being a challenge. The three markers above
+//     already cover the real interstitial (it carries all of them).
+export function hasDdosGuardChallenge(html: string, _headers: Record<string, string> = {}): boolean {
+  if (/\/\.well-known\/ddos-guard\/js-challenge\//i.test(html)) return true
+  if (/id=["']ddg-l10n-(title|description)["']|id=["']ddg-img-loading["']/i.test(html)) return true
+  if (/check\.ddos-guard\.net\/check\.js/i.test(html)) return true
+  return false
+}
+
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
   if (hasTurnstile(html)) return "cloudflare-turnstile"
+  // The authoritative CF header outranks the DDoS-Guard markers, so this agrees with
+  // isCloudflarePage() on a page fronted by both. Grading it ddos-guard here while
+  // isCloudflarePage() said cloudflare sent tiers 3/4 to the DDoS-Guard waiter and
+  // then judged the outcome with the Cloudflare persistence check.
+  if (hasCloudflareChallengeHeader(headers)) return "cloudflare-interstitial"
+  // Otherwise DDoS-Guard precedes the Cloudflare check: its interstitial trips several
+  // of the generic copy-text heuristics inside isCloudflarePage().
+  if (hasDdosGuardChallenge(html, headers)) return "ddos-guard"
   if (isCloudflarePage(html, headers)) return "cloudflare-interstitial"
   if (hasImpervaChallenge(html, headers)) return "imperva"
   if (hasAkamaiChallenge(html, headers)) return "akamai"
@@ -125,11 +171,17 @@ export function isBlocked(status: number, html: string): boolean {
   if (isCloudflarePage(html, {})) return true
   if (hasImpervaChallenge(html)) return true
   if (hasAkamaiChallenge(html)) return true
+  if (hasDdosGuardChallenge(html)) return true
   return false
 }
 
 export function needsJs(html: string, headers: Record<string, string>): boolean {
-  return isCloudflarePage(html, headers) || hasImpervaChallenge(html, headers) || hasAkamaiChallenge(html, headers)
+  return (
+    isCloudflarePage(html, headers) ||
+    hasImpervaChallenge(html, headers) ||
+    hasAkamaiChallenge(html, headers) ||
+    hasDdosGuardChallenge(html, headers)
+  )
 }
 
 // Lean-body threshold per challenge type. When a known challenge returns a response
@@ -139,6 +191,8 @@ export function needsJs(html: string, headers: Record<string, string>): boolean 
 const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
   "cloudflare-interstitial": 3000,
   imperva: 5000,
+  // The AA wall measured 902 bytes; give the same headroom CF gets.
+  "ddos-guard": 3000,
 }
 
 // True if the response is a challenge wall (page access blocked) rather than a page

--- a/packages/tiers/tests/ddosGuardDetection.test.ts
+++ b/packages/tiers/tests/ddosGuardDetection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { detectChallengeType, hasDdosGuardChallenge, isBlocked, isCloudflarePage, needsJs } from "../src/utils/detect"
+
+// Trimmed from a real DDoS-Guard interstitial (annas-archive.gl/search, HTTP 403, 902 bytes).
+const DDG_INTERSTITIAL = `<html><head><title>DDoS-Guard</title>
+<link rel="stylesheet" href="/.well-known/ddos-guard/js-challenge/index.css">
+<script defer src="/.well-known/ddos-guard/js-challenge/view.js"></script>
+<script defer src="/.well-known/ddos-guard/js-challenge/index.js"></script>
+<script src="https://check.ddos-guard.net/check.js"></script></head>
+<body><div id="ddg-img-loading"></div>
+<h1 id="ddg-l10n-title">Checking your browser before accessing <span class="ddg-origin"></span></h1>
+<p id="ddg-l10n-description">Please wait a few seconds. Once this check is complete, the website will open automatically</p>
+<div id="request-info"></div></body></html>`
+
+describe("DDoS-Guard detection", () => {
+  test("the interstitial is graded as ddos-guard, not cloudflare", () => {
+    expect(hasDdosGuardChallenge(DDG_INTERSTITIAL)).toBe(true)
+    expect(detectChallengeType(DDG_INTERSTITIAL)).toBe("ddos-guard")
+    // Regression: it used to match isCloudflarePage(), which routed it into the CF
+    // interstitial wait. That polls for cf_clearance and CF DOM markers a DDoS-Guard
+    // page never emits, so it consumed the whole timeout and reported
+    // "cloudflare-persistent". tiers 3/4 call isCloudflarePage() directly for their
+    // persistence check, so this must be false there too, not merely ordered later
+    // inside detectChallengeType().
+    expect(isCloudflarePage(DDG_INTERSTITIAL, {})).toBe(false)
+  })
+
+  test("the interstitial still counts as blocked and as needing JS", () => {
+    expect(isBlocked(403, DDG_INTERSTITIAL)).toBe(true)
+    expect(needsJs(DDG_INTERSTITIAL, {})).toBe(true)
+  })
+
+  test("a real page from a DDoS-Guard-fronted site is not a challenge", () => {
+    // DDoS-Guard sets `Server: ddos-guard` on every response it fronts — verified on
+    // annas-archive.gl, where the 200 and the 403 interstitial carry the identical
+    // header. Detection must not key off it, or every successful page from such a
+    // site is graded a wall and sent back through the solver forever.
+    const realPage = `<html><head><title>Search results</title></head><body>${"<a href='/md5/abc'>book</a>".repeat(200)}</body></html>`
+    expect(hasDdosGuardChallenge(realPage, { server: "ddos-guard" })).toBe(false)
+    expect(detectChallengeType(realPage, { server: "ddos-guard" })).toBe("none")
+    expect(isBlocked(200, realPage)).toBe(false)
+  })
+
+  test("merely mentioning ddos-guard.net is not a challenge, at any size", () => {
+    // Detection requires challenge-specific evidence (asset paths, DOM ids, check.js).
+    // A bare provider mention is not evidence, and a size gate would not make it so.
+    const small = `<html><body><p>Protected by ddos-guard.net</p></body></html>`
+    const big = `<html><body><p>Protected by ddos-guard.net</p>${"x".repeat(5000)}</body></html>`
+    expect(hasDdosGuardChallenge(small)).toBe(false)
+    expect(hasDdosGuardChallenge(big)).toBe(false)
+  })
+
+  test("an authoritative cf-mitigated header wins over DDoS-Guard markers, consistently", () => {
+    // A page fronted by both must be graded Cloudflare — the CF header is definitive,
+    // the DDoS-Guard markers are heuristics. Both entry points must agree: an earlier
+    // cut had isCloudflarePage() say cloudflare while detectChallengeType() said
+    // ddos-guard, which sent tiers 3/4 to the DDoS-Guard waiter and then judged the
+    // outcome with the Cloudflare persistence check.
+    const cfHeaders = { "cf-mitigated": "challenge" }
+    expect(isCloudflarePage(DDG_INTERSTITIAL, cfHeaders)).toBe(true)
+    expect(detectChallengeType(DDG_INTERSTITIAL, cfHeaders)).toBe("cloudflare-interstitial")
+  })
+})


### PR DESCRIPTION
# fix(tiers): give DDoS-Guard its own detection and wait

## Problem

DDoS-Guard is detected, but graded as Cloudflare. In `packages/tiers/src/utils/detect.ts`:

```ts
export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
  ...
  if (/<title>[^<]*(just a moment|ddos-guard|please wait|checking|attention required)[^<]*<\/title>/i.test(html))
    return true
  ...
  // DDoS-Guard
  if (/ddos-guard\.net|\.ddos-guard\.net/i.test(html)) return true
```

So `detectChallengeType()` returns `cloudflare-interstitial`, and tiers 3 and 4
hand the page to `waitForChallengeResolution()`. That wait polls for
`cf_clearance` and for Cloudflare challenge DOM that a DDoS-Guard page never
emits, so it cannot ever observe success. It runs to the deadline, and the
failure is then reported under a Cloudflare label.

Measured against `https://annas-archive.gl/search?...` (DDoS-Guard, HTTP 403):

```
tier 1  needs-js  1339 ms    cloudflare-challenge
tier 3  timeout   359100 ms  cloudflare-interstitial-challenge-timeout
tier 4  blocked   10608 ms   cloudflare-persistent
```

Tier 4 ran through a genuine residential proxy (verified separately: the proxy
egressed from a residential IP and reached the site). So this is not IP
reputation — the wrong solver is being applied, and no proxy tier can fix that.
The 359s tier-3 timeout is also a real availability cost: it occupies a browser
from the pool for six minutes to accomplish nothing.

## What DDoS-Guard actually serves

A ~900-byte interstitial:

```html
<link rel="stylesheet" href="/.well-known/ddos-guard/js-challenge/index.css">
<script defer src="/.well-known/ddos-guard/js-challenge/view.js"></script>
<script defer src="/.well-known/ddos-guard/js-challenge/index.js"></script>
<script src="https://check.ddos-guard.net/check.js"></script>
<h1 id="ddg-l10n-title">Checking your browser before accessing …</h1>
<p id="ddg-l10n-description">Please wait a few seconds. Once this check is complete,
the website will open automatically</p>
```

The script sets `__ddg*` cookies and the page reloads into the real content.
There is no obfuscation to reimplement — like Imperva's sensor challenge, a real
browser executing real JS satisfies it. The fix is to stop applying Cloudflare
logic and simply wait for the interstitial to clear.

## Change

- `ddos-guard` becomes a first-class `ChallengeType`.
- `hasDdosGuardChallenge()` detects the interstitial.
- `ddosGuardWait.ts` waits for it to clear, modelled directly on `impervaWait.ts`
  including the "cookie set but still on the challenge page" re-navigation path.
- Tiers 3 and 4 dispatch to it and gain a `ddos-guard-persistent` blocked reason.
- `isBlocked()` and `needsJs()` learn about it, and it gets a lean-body threshold
  alongside the Cloudflare and Imperva ones.

## Things worth reviewing closely

**Detection requires challenge-specific evidence only.** Two false-positive traps
were found and closed during review:

- It must not key off `Server: ddos-guard`. DDoS-Guard sets that header on every
  response it fronts — verified on `annas-archive.gl`, where the successful 200
  and the 403 interstitial carry the identical header. Keying on it grades every
  successful page from such a site as a wall.
- A bare `ddos-guard.net` mention is not evidence either, and size-gating it (as
  `__CF$cv$params` and the Akamai bootstrap are) does not fix that: the gate is
  arbitrary, counts UTF-16 units rather than bytes, and still says nothing about
  the page being a challenge. Dropped. The three remaining markers — the
  js-challenge asset paths, the `ddg-l10n-*` / `ddg-img-loading` DOM ids, and
  `check.ddos-guard.net/check.js` — are all present on the real interstitial.

**`cf-mitigated` stays authoritative in both entry points.** It is Cloudflare's
own declaration, so a page fronted by both WAFs still grades as CF; only the
generic copy-text heuristics are overridden. It is factored out as
`hasCloudflareChallengeHeader()` and checked first in *both*
`isCloudflarePage()` and `detectChallengeType()`, because tiers 3/4 use the
latter to choose the waiter and the former for their persistence check — an
earlier cut had them disagree, so such a page was solved as DDoS-Guard and then
judged as Cloudflare.

**The cookie is not the solved signal.** DDoS-Guard sets `__ddg1_`/`__ddgid_`/
`__ddgmark_` on the challenge page itself, so only `__ddg2_`/`__ddg5_` count, and
even then the interstitial clearing is what's authoritative — the cookie merely
decides whether re-navigating is worth trying. An earlier cut matched any
`__ddg*`, which re-navigated ~5s in, yanked the page away from the still-running
challenge script, and then blamed the IP. Reading a pre-existing cookie as
evidence of this solve is safe here because tiers 3 and 4 both run in a
`newFreshContext()` with no carried-over jar.

**Every Playwright call in the loop is deadline-bounded** via a small
`Promise.race` helper, and an empty `page.content()` after re-navigation is not
treated as "no challenge". `.catch()` bounds rejection but not a hang, and a
wedged transport here holds a pooled browser — a failure mode this codebase has
hit before (see the `restartEntry` work in #37). The same reasoning says an empty
read is a failed read, not a solved page.

**The deadline respects the caller's budget.** `impervaWait`/`akamaiWait` use
`Math.max(timeoutMs, 30_000)`, which silently extends a tier past the time the
request asked for and keeps a scarce pooled browser checked out while it does.
This wait uses `timeoutMs` directly. The re-navigation path is bounded to match:
`goto` + `networkidle` + content read can total ~28s, so it is skipped unless
that much budget remains and each call is clamped to what is left. Happy to
align the other two waits in a follow-up if you'd rather they be consistent.

## Not covered

DDoS-Guard also has a checkbox ("I am not a robot") variant on some sites. This
wait does not drive it; such a page falls through to `timeout` rather than being
mis-reported as solved. The JS-only interstitial is what Anna's Archive serves
and is what this was validated against.

## Tests

`packages/tiers/tests/ddosGuardDetection.test.ts` covers the grading fix, the
`isCloudflarePage()` regression specifically, the `Server:` header false-positive,
and the size-gated host match. Full suite: 90 pass, 0 fail.
