### PR TITLE
fix(tiers): handle DDoS-Guard challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Detect and resolve DDoS-Guard JS interstitials without misclassifying them as Cloudflare challenges (#66).
+
 ## [1.4.1] - 2026-08-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-08-22
+
+### Changed
+- Bump all application and internal package versions to `1.4.2`.
+
 ### Fixed
 - Detect and resolve DDoS-Guard JS interstitials without misclassifying them as Cloudflare challenges (#66).
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ image: ghcr.io/germondai/trawl:latest
 image: ghcr.io/germondai/trawl:baseline
 ```
 
-Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. Standard Bun requires kernel 5.1+ (5.6+ recommended); the baseline build degrades gracefully down to kernel 3.10. The `:baseline` tag is published for that case — **confirmed working** on a Synology DS920+ (Celeron J4125, DSM 7.3.2, kernel 4.4.302): the container starts cleanly, `/health` reports healthy, and it solves live Cloudflare challenges via `/v1` (see [#1](https://github.com/germondai/trawl/issues/1)). Published by independent GitHub Actions workflows: pushing `v1.4.1` creates `:1.4.1`, `:latest`, `:1.4.1-baseline`, and `:baseline`; pushing `main` creates `:nightly` and `:nightly-<sha>`.
+Synology note: many Synology NAS units (DSM 7.x on J4125 / older hardware) ship kernel 4.4.x, which Bun's modern runtime can't fully handle. Standard Bun requires kernel 5.1+ (5.6+ recommended); the baseline build degrades gracefully down to kernel 3.10. The `:baseline` tag is published for that case — **confirmed working** on a Synology DS920+ (Celeron J4125, DSM 7.3.2, kernel 4.4.302): the container starts cleanly, `/health` reports healthy, and it solves live Cloudflare challenges via `/v1` (see [#1](https://github.com/germondai/trawl/issues/1)). Published by independent GitHub Actions workflows: pushing `v1.4.2` creates `:1.4.2`, `:latest`, `:1.4.2-baseline`, and `:baseline`; pushing `main` creates `:nightly` and `:nightly-<sha>`.
 
 ## Releases & versioning
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/api",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "dev": "bun run --watch src/index.ts",

--- a/apps/docs/api-reference/health-stats.md
+++ b/apps/docs/api-reference/health-stats.md
@@ -18,7 +18,7 @@ FlareSolverr-style readiness message — confirms the API process is up (does no
 ```json
 {
   "msg": "TRAWL is ready!",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "uptime": 42
 }
 ```

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/docs",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/web",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "dev": "nuxt dev",

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/api": {
       "name": "@trawl/api",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@trawl/browser": "workspace:*",
         "@trawl/tiers": "workspace:*",
@@ -27,14 +27,14 @@
     },
     "apps/docs": {
       "name": "@trawl/docs",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "devDependencies": {
         "vitepress": "^1.6.4",
       },
     },
     "apps/web": {
       "name": "@trawl/web",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "devDependencies": {
         "@nuxt/fonts": "^0.14.0",
         "@nuxtjs/color-mode": "^4.0.1",
@@ -47,7 +47,7 @@
     },
     "packages/browser": {
       "name": "@trawl/browser",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@trawl/types": "workspace:*",
         "camoufox-js": "0.12.0",
@@ -61,7 +61,7 @@
     },
     "packages/tiers": {
       "name": "@trawl/tiers",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@trawl/browser": "workspace:*",
         "@trawl/types": "workspace:*",
@@ -74,7 +74,7 @@
     },
     "packages/types": {
       "name": "@trawl/types",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "devDependencies": {
         "typescript": "^7.0.2",
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "trawl",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/browser",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/tiers/package.json
+++ b/packages/tiers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/tiers",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -9,6 +9,7 @@ export {
   type ChallengeType,
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasHcaptcha,
   hasImpervaChallenge,
   hasRecaptcha,

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -2,12 +2,9 @@ import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
 import { solvePageCaptchas } from "../solvers"
-import { waitForAkamaiResolution } from "../utils/akamaiWait"
-import { waitForChallengeResolution } from "../utils/challengeWait"
+import { routeChallengeWait } from "../utils/challengeRouter"
 import { toCookies } from "../utils/cookies"
-import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
-  detectChallengeType,
   hasAkamaiChallenge,
   hasDdosGuardChallenge,
   hasImpervaChallenge,
@@ -16,7 +13,6 @@ import {
   isCloudflarePage,
 } from "../utils/detect"
 import { normalizeHtml } from "../utils/html"
-import { waitForImpervaResolution } from "../utils/impervaWait"
 import { trackMainDocumentResponses } from "../utils/mainResponse"
 import { isHardNetworkFailure } from "../utils/network"
 import { captureResponse, isTextContentType } from "../utils/response"
@@ -87,15 +83,7 @@ export async function runTier3(
 
     const remaining = maxTimeout - (Date.now() - start)
     const peekHtml = await page.content().catch(() => "")
-    const challengeType = detectChallengeType(peekHtml)
-    const resolution =
-      challengeType === "imperva"
-        ? await waitForImpervaResolution(page, remaining, url)
-        : challengeType === "akamai"
-          ? await waitForAkamaiResolution(page, remaining, url)
-          : challengeType === "ddos-guard"
-            ? await waitForDdosGuardResolution(page, remaining, url)
-            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+    const { challengeType, resolution } = await routeChallengeWait(page, peekHtml, mainResponse.headers, remaining, url)
 
     if (resolution !== "ok") {
       return {
@@ -110,7 +98,7 @@ export async function runTier3(
                 ? "datacenter-ip-blocked (Akamai sensor cookie obtained but challenge persisted — needs residential proxy)"
                 : challengeType === "ddos-guard"
                   ? "datacenter-ip-blocked (DDoS-Guard clearance cookie obtained but challenge persisted — needs residential proxy)"
-                : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
+                  : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
             : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
     }

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -5,9 +5,11 @@ import { solvePageCaptchas } from "../solvers"
 import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
+import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -91,7 +93,9 @@ export async function runTier3(
         ? await waitForImpervaResolution(page, remaining, url)
         : challengeType === "akamai"
           ? await waitForAkamaiResolution(page, remaining, url)
-          : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+          : challengeType === "ddos-guard"
+            ? await waitForDdosGuardResolution(page, remaining, url)
+            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
 
     if (resolution !== "ok") {
       return {
@@ -104,6 +108,8 @@ export async function runTier3(
               ? "datacenter-ip-blocked (imperva sensor cookie obtained but challenge persisted — needs residential proxy)"
               : challengeType === "akamai"
                 ? "datacenter-ip-blocked (Akamai sensor cookie obtained but challenge persisted — needs residential proxy)"
+                : challengeType === "ddos-guard"
+                  ? "datacenter-ip-blocked (DDoS-Guard clearance cookie obtained but challenge persisted — needs residential proxy)"
                 : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
             : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
@@ -160,6 +166,13 @@ export async function runTier3(
       const pageUrl = page.url()
       console.log(`[tier3] akamai-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
       return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "akamai-persistent" }
+    }
+
+    if (hasDdosGuardChallenge(html)) {
+      const pageTitle = await page.title().catch(() => "?")
+      const pageUrl = page.url()
+      console.log(`[tier3] ddos-guard-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
+      return { tier: 3, status: "blocked", durationMs: Date.now() - start, reason: "ddos-guard-persistent" }
     }
 
     if (isBlocked(mainResponse.status, html)) {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -2,12 +2,9 @@ import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
 import { solvePageCaptchas } from "../solvers"
-import { waitForAkamaiResolution } from "../utils/akamaiWait"
-import { waitForChallengeResolution } from "../utils/challengeWait"
+import { routeChallengeWait } from "../utils/challengeRouter"
 import { toCookies } from "../utils/cookies"
-import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
-  detectChallengeType,
   hasAkamaiChallenge,
   hasDdosGuardChallenge,
   hasImpervaChallenge,
@@ -16,7 +13,6 @@ import {
   isCloudflarePage,
 } from "../utils/detect"
 import { normalizeHtml } from "../utils/html"
-import { waitForImpervaResolution } from "../utils/impervaWait"
 import { trackMainDocumentResponses } from "../utils/mainResponse"
 import { isHardNetworkFailure } from "../utils/network"
 import { captureResponse, isTextContentType } from "../utils/response"
@@ -84,15 +80,7 @@ export async function runTier4(
 
     const remaining = maxTimeout - (Date.now() - start)
     const peekHtml = await page.content().catch(() => "")
-    const challengeType = detectChallengeType(peekHtml)
-    const resolution =
-      challengeType === "imperva"
-        ? await waitForImpervaResolution(page, remaining, url)
-        : challengeType === "akamai"
-          ? await waitForAkamaiResolution(page, remaining, url)
-          : challengeType === "ddos-guard"
-            ? await waitForDdosGuardResolution(page, remaining, url)
-            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+    const { challengeType, resolution } = await routeChallengeWait(page, peekHtml, mainResponse.headers, remaining, url)
 
     if (resolution !== "ok") {
       return {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -5,9 +5,11 @@ import { solvePageCaptchas } from "../solvers"
 import { waitForAkamaiResolution } from "../utils/akamaiWait"
 import { waitForChallengeResolution } from "../utils/challengeWait"
 import { toCookies } from "../utils/cookies"
+import { waitForDdosGuardResolution } from "../utils/ddosGuardWait"
 import {
   detectChallengeType,
   hasAkamaiChallenge,
+  hasDdosGuardChallenge,
   hasImpervaChallenge,
   isBlocked,
   isBrowserErrorPage,
@@ -88,7 +90,9 @@ export async function runTier4(
         ? await waitForImpervaResolution(page, remaining, url)
         : challengeType === "akamai"
           ? await waitForAkamaiResolution(page, remaining, url)
-          : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
+          : challengeType === "ddos-guard"
+            ? await waitForDdosGuardResolution(page, remaining, url)
+            : await waitForChallengeResolution(page, remaining, url, () => mainResponse.headers)
 
     if (resolution !== "ok") {
       return {
@@ -153,6 +157,13 @@ export async function runTier4(
         durationMs: Date.now() - start,
         reason: "akamai-persistent",
       }
+    }
+
+    if (hasDdosGuardChallenge(html)) {
+      const pageTitle = await page.title().catch(() => "?")
+      const pageUrl = page.url()
+      console.log(`[tier4] ddos-guard-persistent: url="${pageUrl}" title="${pageTitle}" html=${html.length}b`)
+      return { tier: 4, status: "blocked", durationMs: Date.now() - start, reason: "ddos-guard-persistent" }
     }
 
     if (isBlocked(mainResponse.status, html)) {

--- a/packages/tiers/src/utils/challengeRouter.ts
+++ b/packages/tiers/src/utils/challengeRouter.ts
@@ -1,0 +1,48 @@
+import type { Page } from "patchright"
+import { waitForAkamaiResolution } from "./akamaiWait"
+import { waitForChallengeResolution } from "./challengeWait"
+import { waitForDdosGuardResolution } from "./ddosGuardWait"
+import { type ChallengeType, detectChallengeType } from "./detect"
+import { waitForImpervaResolution } from "./impervaWait"
+
+type Resolution = "ok" | "ip-blocked" | "timeout"
+type Waiter = (page: Page, timeoutMs: number, originalUrl?: string) => Promise<Resolution>
+
+interface ChallengeWaiters {
+  cloudflare: (
+    page: Page,
+    timeoutMs: number,
+    originalUrl?: string,
+    responseHeaders?: () => Record<string, string>,
+  ) => Promise<Resolution>
+  imperva: Waiter
+  akamai: Waiter
+  ddosGuard: Waiter
+}
+
+const defaultWaiters: ChallengeWaiters = {
+  cloudflare: waitForChallengeResolution,
+  imperva: waitForImpervaResolution,
+  akamai: waitForAkamaiResolution,
+  ddosGuard: waitForDdosGuardResolution,
+}
+
+export async function routeChallengeWait(
+  page: Page,
+  html: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+  originalUrl?: string,
+  waiters: ChallengeWaiters = defaultWaiters,
+): Promise<{ challengeType: ChallengeType; resolution: Resolution }> {
+  const challengeType = detectChallengeType(html, headers)
+  const resolution =
+    challengeType === "imperva"
+      ? await waiters.imperva(page, timeoutMs, originalUrl)
+      : challengeType === "akamai"
+        ? await waiters.akamai(page, timeoutMs, originalUrl)
+        : challengeType === "ddos-guard"
+          ? await waiters.ddosGuard(page, timeoutMs, originalUrl)
+          : await waiters.cloudflare(page, timeoutMs, originalUrl, () => headers)
+  return { challengeType, resolution }
+}

--- a/packages/tiers/src/utils/ddosGuardWait.ts
+++ b/packages/tiers/src/utils/ddosGuardWait.ts
@@ -1,0 +1,163 @@
+// DDoS-Guard JS-challenge wait — mirrors impervaWait.ts's cookie polling loop.
+// DDoS-Guard serves a ~900-byte interstitial that loads
+// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
+// says "Checking your browser before accessing", and reloads into the real content once
+// its script has set the __ddg* cookies. Like Imperva's sensor challenge, a real browser
+// running real JS satisfies it — there is no obfuscation to reimplement, so we just wait
+// for the interstitial to go away.
+//
+// Before this existed, DDoS-Guard was folded into isCloudflarePage() and handled by
+// waitForChallengeResolution(), which polls for cf_clearance and Cloudflare DOM markers
+// that a DDoS-Guard page never emits. That burned the entire timeout and then reported
+// the failure as "cloudflare-persistent".
+//
+// Known risk: DDoS-Guard also has a checkbox ("I am not a robot") variant on some sites.
+// This wait does not drive it — the JS-only interstitial is what Anna's Archive serves,
+// which is what this was written and validated against. A checkbox page will fall through
+// to "timeout" rather than being mis-reported as solved.
+
+import type { Page } from "patchright"
+import { hasDdosGuardChallenge } from "./detect"
+
+// Two retries is enough to tell a missed auto-reload from a wall that keeps coming
+// back. Beyond that the browser is being held for nothing.
+const MAX_RENAVIGATIONS = 2
+
+// page.content() / context.cookies() can hang rather than reject when the browser
+// transport wedges — .catch() does not bound that, and a hang here holds a pooled
+// browser past the deadline. This service has already been bitten by pool entries
+// pinned by unbounded awaits, so every Playwright call in the loop goes through here.
+function bounded<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    p.catch(() => fallback),
+    new Promise<T>((r) => setTimeout(() => r(fallback), ms)),
+  ])
+}
+
+export async function waitForDdosGuardResolution(
+  page: Page,
+  timeoutMs: number,
+  originalUrl?: string,
+): Promise<"ok" | "ip-blocked" | "timeout"> {
+  // Never exceed the caller's budget. impervaWait/akamaiWait use Math.max(timeoutMs,
+  // 30_000), which silently extends a tier past the time the request asked for and
+  // keeps a scarce pooled browser checked out while it does.
+  const deadline = Date.now() + timeoutMs
+  const remaining = () => deadline - Date.now()
+  // goto + networkidle + content read can add up to ~28s. Skipping the re-navigation
+  // when less than that remains is what actually keeps the wait inside timeoutMs;
+  // clamping each individual call below then handles the boundary case.
+  const RENAV_BUDGET_MS = 28_000
+  let clearanceCookieAt: number | undefined
+  let lastRenavAt = 0
+  let sawPersistentChallenge = false
+  let cookieNamesLogged = false
+  let renavCount = 0
+
+  const targetHost = (() => {
+    try {
+      return new URL(originalUrl ?? page.url()).hostname
+    } catch {
+      return ""
+    }
+  })()
+
+  const earlyHtml = await bounded(page.content(), 5_000, "")
+  if (earlyHtml && !hasDdosGuardChallenge(earlyHtml)) {
+    await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {})
+    return "ok"
+  }
+
+  // Let the challenge script boot before polling
+  await new Promise((r) => setTimeout(r, 1000))
+
+  while (Date.now() < deadline) {
+    try {
+      // The interstitial clearing is the authoritative signal, not the cookie: DDoS-Guard
+      // sets __ddg1_/__ddgid_ style markers on the challenge page itself, so a cookie
+      // alone does not mean solved. Cookies are only used to decide whether it is worth
+      // re-navigating below.
+      const html = await bounded(page.content(), 5_000, "")
+      if (html && !hasDdosGuardChallenge(html)) {
+        await page.waitForLoadState("load", { timeout: 5000 }).catch(() => {})
+        return "ok"
+      }
+
+      const cookies: Array<{ name: string; domain: string }> = await bounded(
+        page.context().cookies(),
+        5_000,
+        [] as Array<{ name: string; domain: string }>,
+      )
+      const onTargetHost = (c: { domain: string }) =>
+        targetHost &&
+        (c.domain === targetHost ||
+          c.domain === `.${targetHost}` ||
+          targetHost.endsWith(c.domain.replace(/^\./, "")))
+      // __ddg1_/__ddgid_/__ddgmark_ are set by the interstitial itself, so matching
+      // any __ddg* cookie says nothing about having passed. Only the post-challenge
+      // cookies count. Matching broadly here meant re-navigating ~5s in, which yanked
+      // the page away from the still-running challenge script and then graded the
+      // result "ip-blocked" — reproduced from a residential IP, where an actual IP
+      // block was not plausible.
+      // Safe to read a pre-existing cookie as evidence of THIS solve: tiers 3 and 4
+      // both run in a newFreshContext() with no carried-over cookie jar, so anything
+      // here was set during this navigation.
+      const hasClearanceCookie = cookies.some((c) => /^__ddg[25]_/.test(c.name) && onTargetHost(c))
+
+      if (cookieNamesLogged === false && cookies.length > 0) {
+        cookieNamesLogged = true
+        console.log(`[ddos-guard] cookies so far: ${cookies.map((c) => c.name).join(", ") || "(none)"}`)
+      }
+
+      if (hasClearanceCookie) {
+        if (clearanceCookieAt === undefined) {
+          clearanceCookieAt = Date.now()
+          console.log("[ddos-guard] clearance cookie obtained")
+        }
+
+        // Cookie set but still on the interstitial — the auto-reload does not always
+        // fire. Navigate ourselves after a grace period, same as the Imperva path.
+        // Unlike Imperva we do NOT conclude on the first re-navigation: DDoS-Guard
+        // re-challenges cheaply, and one persisting interstitial is not evidence of
+        // an IP block. Keep polling until the deadline and let the caller escalate.
+        if (
+          originalUrl &&
+          Date.now() - clearanceCookieAt > 8000 &&
+          Date.now() - lastRenavAt > 15_000 &&
+          renavCount < MAX_RENAVIGATIONS &&
+          remaining() > RENAV_BUDGET_MS
+        ) {
+          lastRenavAt = Date.now()
+          renavCount++
+          console.log(
+            `[ddos-guard] cookie set but still on challenge page — navigating to original URL (${renavCount}/${MAX_RENAVIGATIONS})`,
+          )
+          const clamp = (ms: number) => Math.max(500, Math.min(ms, remaining()))
+          await page.goto(originalUrl, { waitUntil: "domcontentloaded", timeout: clamp(15_000) }).catch(() => {})
+          await page.waitForLoadState("networkidle", { timeout: clamp(8_000) }).catch(() => {})
+          const html2 = await bounded(page.content(), clamp(5_000), "")
+          // `html2 &&` matters: a goto timeout or a crashed page yields "", which the
+          // detector reports as "no challenge". Without the guard a navigation failure
+          // returns "ok" and the tier hands back an empty document as a solved page.
+          if (html2 && !hasDdosGuardChallenge(html2)) return "ok"
+          if (html2) sawPersistentChallenge = true
+        }
+
+        // Full clearance cookie set, and the wall came straight back every time we
+        // retried. Nothing further here will change that — the site is rejecting the
+        // request on something other than the JS challenge — so give the browser back
+        // rather than sitting on it until the deadline.
+        if (sawPersistentChallenge && renavCount >= MAX_RENAVIGATIONS) return "ip-blocked"
+      }
+    } catch {
+      // Page is mid-navigation — keep polling
+    }
+
+    await new Promise((r) => setTimeout(r, 300))
+  }
+
+  // Distinguish "we passed the JS challenge but the wall stayed up" (a reputation
+  // signal worth escalating to a residential proxy) from "the challenge never
+  // completed at all" (a timeout).
+  return sawPersistentChallenge ? "ip-blocked" : "timeout"
+}

--- a/packages/tiers/src/utils/ddosGuardWait.ts
+++ b/packages/tiers/src/utils/ddosGuardWait.ts
@@ -1,58 +1,56 @@
-// DDoS-Guard JS-challenge wait — mirrors impervaWait.ts's cookie polling loop.
-// DDoS-Guard serves a ~900-byte interstitial that loads
-// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
-// says "Checking your browser before accessing", and reloads into the real content once
-// its script has set the __ddg* cookies. Like Imperva's sensor challenge, a real browser
-// running real JS satisfies it — there is no obfuscation to reimplement, so we just wait
-// for the interstitial to go away.
-//
-// Before this existed, DDoS-Guard was folded into isCloudflarePage() and handled by
-// waitForChallengeResolution(), which polls for cf_clearance and Cloudflare DOM markers
-// that a DDoS-Guard page never emits. That burned the entire timeout and then reported
-// the failure as "cloudflare-persistent".
-//
-// Known risk: DDoS-Guard also has a checkbox ("I am not a robot") variant on some sites.
-// This wait does not drive it — the JS-only interstitial is what Anna's Archive serves,
-// which is what this was written and validated against. A checkbox page will fall through
-// to "timeout" rather than being mis-reported as solved.
-
 import type { Page } from "patchright"
 import { hasDdosGuardChallenge } from "./detect"
 
-// Two retries is enough to tell a missed auto-reload from a wall that keeps coming
-// back. Beyond that the browser is being held for nothing.
-const MAX_RENAVIGATIONS = 2
+type Resolution = "ok" | "ip-blocked" | "timeout"
 
-// page.content() / context.cookies() can hang rather than reject when the browser
-// transport wedges — .catch() does not bound that, and a hang here holds a pooled
-// browser past the deadline. This service has already been bitten by pool entries
-// pinned by unbounded awaits, so every Playwright call in the loop goes through here.
-function bounded<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
-  return Promise.race([
-    p.catch(() => fallback),
-    new Promise<T>((r) => setTimeout(() => r(fallback), ms)),
-  ])
+interface WaitOptions {
+  pollMs?: number
+  renavigationGraceMs?: number
+  renavigationIntervalMs?: number
+  maxRenavigations?: number
+}
+
+const failedRead = { failed: true } as const
+
+function isFailedRead(value: unknown): value is typeof failedRead {
+  return value === failedRead
+}
+
+// Unlike a bare Promise.race, this clears its timer when Playwright settles first.
+// Playwright operations that expose a timeout also receive the same remaining budget.
+async function withinBudget<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof failedRead> {
+  if (timeoutMs <= 0) return failedRead
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      new Promise<T | typeof failedRead>((resolve) => promise.then(resolve, () => resolve(failedRead))),
+      new Promise<typeof failedRead>((resolve) => {
+        timer = setTimeout(() => resolve(failedRead), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
 }
 
 export async function waitForDdosGuardResolution(
   page: Page,
   timeoutMs: number,
   originalUrl?: string,
-): Promise<"ok" | "ip-blocked" | "timeout"> {
-  // Never exceed the caller's budget. impervaWait/akamaiWait use Math.max(timeoutMs,
-  // 30_000), which silently extends a tier past the time the request asked for and
-  // keeps a scarce pooled browser checked out while it does.
+  options: WaitOptions = {},
+): Promise<Resolution> {
+  if (timeoutMs <= 0) return "timeout"
+
   const deadline = Date.now() + timeoutMs
-  const remaining = () => deadline - Date.now()
-  // goto + networkidle + content read can add up to ~28s. Skipping the re-navigation
-  // when less than that remains is what actually keeps the wait inside timeoutMs;
-  // clamping each individual call below then handles the boundary case.
-  const RENAV_BUDGET_MS = 28_000
-  let clearanceCookieAt: number | undefined
-  let lastRenavAt = 0
-  let sawPersistentChallenge = false
-  let cookieNamesLogged = false
-  let renavCount = 0
+  const remaining = () => Math.max(0, deadline - Date.now())
+  const pollMs = options.pollMs ?? 300
+  const renavigationGraceMs = options.renavigationGraceMs ?? 8000
+  const renavigationIntervalMs = options.renavigationIntervalMs ?? 15_000
+  const maxRenavigations = options.maxRenavigations ?? 2
+  let clearanceAt: number | undefined
+  let lastRenavigationAt = 0
+  let renavigations = 0
+  let persistentAfterRenavigation = false
 
   const targetHost = (() => {
     try {
@@ -62,102 +60,53 @@ export async function waitForDdosGuardResolution(
     }
   })()
 
-  const earlyHtml = await bounded(page.content(), 5_000, "")
-  if (earlyHtml && !hasDdosGuardChallenge(earlyHtml)) {
-    await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {})
-    return "ok"
-  }
-
-  // Let the challenge script boot before polling
-  await new Promise((r) => setTimeout(r, 1000))
-
-  while (Date.now() < deadline) {
-    try {
-      // The interstitial clearing is the authoritative signal, not the cookie: DDoS-Guard
-      // sets __ddg1_/__ddgid_ style markers on the challenge page itself, so a cookie
-      // alone does not mean solved. Cookies are only used to decide whether it is worth
-      // re-navigating below.
-      const html = await bounded(page.content(), 5_000, "")
-      if (html && !hasDdosGuardChallenge(html)) {
-        await page.waitForLoadState("load", { timeout: 5000 }).catch(() => {})
-        return "ok"
-      }
-
-      const cookies: Array<{ name: string; domain: string }> = await bounded(
-        page.context().cookies(),
-        5_000,
-        [] as Array<{ name: string; domain: string }>,
-      )
-      const onTargetHost = (c: { domain: string }) =>
-        targetHost &&
-        (c.domain === targetHost ||
-          c.domain === `.${targetHost}` ||
-          targetHost.endsWith(c.domain.replace(/^\./, "")))
-      // __ddg1_/__ddgid_/__ddgmark_ are set by the interstitial itself, so matching
-      // any __ddg* cookie says nothing about having passed. Only the post-challenge
-      // cookies count. Matching broadly here meant re-navigating ~5s in, which yanked
-      // the page away from the still-running challenge script and then graded the
-      // result "ip-blocked" — reproduced from a residential IP, where an actual IP
-      // block was not plausible.
-      // Safe to read a pre-existing cookie as evidence of THIS solve: tiers 3 and 4
-      // both run in a newFreshContext() with no carried-over cookie jar, so anything
-      // here was set during this navigation.
-      const hasClearanceCookie = cookies.some((c) => /^__ddg[25]_/.test(c.name) && onTargetHost(c))
-
-      if (cookieNamesLogged === false && cookies.length > 0) {
-        cookieNamesLogged = true
-        console.log(`[ddos-guard] cookies so far: ${cookies.map((c) => c.name).join(", ") || "(none)"}`)
-      }
-
-      if (hasClearanceCookie) {
-        if (clearanceCookieAt === undefined) {
-          clearanceCookieAt = Date.now()
-          console.log("[ddos-guard] clearance cookie obtained")
-        }
-
-        // Cookie set but still on the interstitial — the auto-reload does not always
-        // fire. Navigate ourselves after a grace period, same as the Imperva path.
-        // Unlike Imperva we do NOT conclude on the first re-navigation: DDoS-Guard
-        // re-challenges cheaply, and one persisting interstitial is not evidence of
-        // an IP block. Keep polling until the deadline and let the caller escalate.
-        if (
-          originalUrl &&
-          Date.now() - clearanceCookieAt > 8000 &&
-          Date.now() - lastRenavAt > 15_000 &&
-          renavCount < MAX_RENAVIGATIONS &&
-          remaining() > RENAV_BUDGET_MS
-        ) {
-          lastRenavAt = Date.now()
-          renavCount++
-          console.log(
-            `[ddos-guard] cookie set but still on challenge page — navigating to original URL (${renavCount}/${MAX_RENAVIGATIONS})`,
-          )
-          const clamp = (ms: number) => Math.max(500, Math.min(ms, remaining()))
-          await page.goto(originalUrl, { waitUntil: "domcontentloaded", timeout: clamp(15_000) }).catch(() => {})
-          await page.waitForLoadState("networkidle", { timeout: clamp(8_000) }).catch(() => {})
-          const html2 = await bounded(page.content(), clamp(5_000), "")
-          // `html2 &&` matters: a goto timeout or a crashed page yields "", which the
-          // detector reports as "no challenge". Without the guard a navigation failure
-          // returns "ok" and the tier hands back an empty document as a solved page.
-          if (html2 && !hasDdosGuardChallenge(html2)) return "ok"
-          if (html2) sawPersistentChallenge = true
-        }
-
-        // Full clearance cookie set, and the wall came straight back every time we
-        // retried. Nothing further here will change that — the site is rejecting the
-        // request on something other than the JS challenge — so give the browser back
-        // rather than sitting on it until the deadline.
-        if (sawPersistentChallenge && renavCount >= MAX_RENAVIGATIONS) return "ip-blocked"
-      }
-    } catch {
-      // Page is mid-navigation — keep polling
+  while (remaining() > 0) {
+    const html = await withinBudget(page.content(), remaining())
+    // An empty or unreadable document is never evidence that the wall cleared.
+    if (!isFailedRead(html) && html.length > 0 && !hasDdosGuardChallenge(html)) {
+      await withinBudget(page.waitForLoadState("load", { timeout: remaining() }), remaining())
+      return "ok"
     }
 
-    await new Promise((r) => setTimeout(r, 300))
+    const cookies = await withinBudget(page.context().cookies(), remaining())
+    if (!isFailedRead(cookies)) {
+      const hasClearance = cookies.some((cookie) => {
+        const cookieHost = cookie.domain.replace(/^\./, "")
+        const onTargetHost = targetHost && (targetHost === cookieHost || targetHost.endsWith(`.${cookieHost}`))
+        return onTargetHost && /^__ddg[25]_/.test(cookie.name)
+      })
+
+      if (hasClearance) {
+        clearanceAt ??= Date.now()
+        const canRenavigate =
+          originalUrl &&
+          Date.now() - clearanceAt >= renavigationGraceMs &&
+          Date.now() - lastRenavigationAt >= renavigationIntervalMs &&
+          renavigations < maxRenavigations
+
+        if (canRenavigate && remaining() > 0) {
+          lastRenavigationAt = Date.now()
+          renavigations++
+          await withinBudget(
+            page.goto(originalUrl, { waitUntil: "domcontentloaded", timeout: remaining() }),
+            remaining(),
+          )
+          if (remaining() <= 0) return "timeout"
+          await withinBudget(page.waitForLoadState("networkidle", { timeout: remaining() }), remaining())
+          if (remaining() <= 0) return "timeout"
+          const navigatedHtml = await withinBudget(page.content(), remaining())
+          if (!isFailedRead(navigatedHtml) && navigatedHtml.length > 0) {
+            if (!hasDdosGuardChallenge(navigatedHtml)) return "ok"
+            persistentAfterRenavigation = true
+          }
+          if (persistentAfterRenavigation && renavigations >= maxRenavigations) return "ip-blocked"
+        }
+      }
+    }
+
+    const delay = Math.min(pollMs, remaining())
+    if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
   }
 
-  // Distinguish "we passed the JS challenge but the wall stayed up" (a reputation
-  // signal worth escalating to a residential proxy) from "the challenge never
-  // completed at all" (a timeout).
-  return sawPersistentChallenge ? "ip-blocked" : "timeout"
+  return persistentAfterRenavigation ? "ip-blocked" : "timeout"
 }

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -6,13 +6,29 @@ export type ChallengeType =
   | "cap"
   | "imperva"
   | "akamai"
+  | "ddos-guard"
   | "none"
 
-export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
+// Cloudflare's own declaration that it is serving a challenge. Authoritative, unlike
+// every other check here, so it outranks the DDoS-Guard markers wherever the two meet.
+export function hasCloudflareChallengeHeader(headers: Record<string, string> = {}): boolean {
   const cfMitigated = Object.entries(headers).find(([name]) => name.toLowerCase() === "cf-mitigated")?.[1]
-  if (cfMitigated?.toLowerCase() === "challenge") return true
-  if (/<title>[^<]*(just a moment|ddos-guard|please wait|checking|attention required)[^<]*<\/title>/i.test(html))
-    return true
+  return cfMitigated?.toLowerCase() === "challenge"
+}
+
+export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
+  if (hasCloudflareChallengeHeader(headers)) return true
+  // Otherwise DDoS-Guard wins over the generic copy-text heuristics below: its
+  // interstitial says "Checking your browser before accessing", which they also match.
+  // This is an early return rather than ordering inside detectChallengeType() because
+  // tiers 3/4 call isCloudflarePage() directly for their persistence check.
+  if (hasDdosGuardChallenge(html, headers)) return false
+  // "ddos-guard" deliberately absent: DDoS-Guard is its own WAF with its own solve
+  // path (see hasDdosGuardChallenge / ddosGuardWait.ts). Matching it here routed it
+  // into the Cloudflare interstitial flow, which waits on cf_clearance and CF DOM
+  // markers that a DDoS-Guard page never emits — so it burned the whole timeout and
+  // then reported "cloudflare-persistent".
+  if (/<title>[^<]*(just a moment|please wait|checking|attention required)[^<]*<\/title>/i.test(html)) return true
   if (/checking your browser/i.test(html)) return true
   if (/enable javascript and cookies to continue/i.test(html)) return true
   if (/verify you are human/i.test(html)) return true
@@ -26,8 +42,6 @@ export function isCloudflarePage(html: string, headers: Record<string, string>):
   if (/_cf_chl_opt/i.test(html)) return true
   if (/id=["']challenge-form["']/i.test(html)) return true
   if (/orchestrate\/chl_page/i.test(html)) return true
-  // DDoS-Guard
-  if (/ddos-guard\.net|\.ddos-guard\.net/i.test(html)) return true
   // CF firewall/WAF deny page (error 1020 and friends) — static "blocked" page, not a
   // solvable JS challenge, but still needs to be recognized as CF so the orchestrator
   // reports tier failure and escalates instead of returning the block page as content
@@ -108,8 +122,40 @@ export function hasAkamaiChallenge(html: string, _headers: Record<string, string
   return false
 }
 
+// DDoS-Guard JS interstitial. The wall is a ~900-byte page that loads
+// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
+// shows "Checking your browser before accessing", and reloads into the real content once
+// the script has set the __ddg* cookies. A real browser executing real JS satisfies it
+// without challenge-specific logic, so — like Imperva — we detect the page and wait for
+// the cookie (see ddosGuardWait.ts).
+//
+// Every marker below is challenge-specific: the js-challenge asset paths, the
+// interstitial's own DOM ids, and its check.js. Deliberately NOT matched:
+//
+//   - `Server: ddos-guard` — present on every response DDoS-Guard fronts. Verified on
+//     annas-archive.gl, where the successful 200 and the 403 interstitial carry the
+//     identical header, so keying on it grades real content as a wall forever.
+//   - a bare `ddos-guard.net` mention — any page may link the provider. Size-gating it
+//     is not a fix: the gate is arbitrary, counts UTF-16 units rather than bytes, and
+//     still says nothing about the page being a challenge. The three markers above
+//     already cover the real interstitial (it carries all of them).
+export function hasDdosGuardChallenge(html: string, _headers: Record<string, string> = {}): boolean {
+  if (/\/\.well-known\/ddos-guard\/js-challenge\//i.test(html)) return true
+  if (/id=["']ddg-l10n-(title|description)["']|id=["']ddg-img-loading["']/i.test(html)) return true
+  if (/check\.ddos-guard\.net\/check\.js/i.test(html)) return true
+  return false
+}
+
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
   if (hasTurnstile(html)) return "cloudflare-turnstile"
+  // The authoritative CF header outranks the DDoS-Guard markers, so this agrees with
+  // isCloudflarePage() on a page fronted by both. Grading it ddos-guard here while
+  // isCloudflarePage() said cloudflare sent tiers 3/4 to the DDoS-Guard waiter and
+  // then judged the outcome with the Cloudflare persistence check.
+  if (hasCloudflareChallengeHeader(headers)) return "cloudflare-interstitial"
+  // Otherwise DDoS-Guard precedes the Cloudflare check: its interstitial trips several
+  // of the generic copy-text heuristics inside isCloudflarePage().
+  if (hasDdosGuardChallenge(html, headers)) return "ddos-guard"
   if (isCloudflarePage(html, headers)) return "cloudflare-interstitial"
   if (hasImpervaChallenge(html, headers)) return "imperva"
   if (hasAkamaiChallenge(html, headers)) return "akamai"
@@ -125,11 +171,17 @@ export function isBlocked(status: number, html: string): boolean {
   if (isCloudflarePage(html, {})) return true
   if (hasImpervaChallenge(html)) return true
   if (hasAkamaiChallenge(html)) return true
+  if (hasDdosGuardChallenge(html)) return true
   return false
 }
 
 export function needsJs(html: string, headers: Record<string, string>): boolean {
-  return isCloudflarePage(html, headers) || hasImpervaChallenge(html, headers) || hasAkamaiChallenge(html, headers)
+  return (
+    isCloudflarePage(html, headers) ||
+    hasImpervaChallenge(html, headers) ||
+    hasAkamaiChallenge(html, headers) ||
+    hasDdosGuardChallenge(html, headers)
+  )
 }
 
 // Lean-body threshold per challenge type. When a known challenge returns a response
@@ -139,6 +191,8 @@ export function needsJs(html: string, headers: Record<string, string>): boolean 
 const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
   "cloudflare-interstitial": 3000,
   imperva: 5000,
+  // The AA wall measured 902 bytes; give the same headroom CF gets.
+  "ddos-guard": 3000,
 }
 
 // True if the response is a challenge wall (page access blocked) rather than a page

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -9,8 +9,6 @@ export type ChallengeType =
   | "ddos-guard"
   | "none"
 
-// Cloudflare's own declaration that it is serving a challenge. Authoritative, unlike
-// every other check here, so it outranks the DDoS-Guard markers wherever the two meet.
 export function hasCloudflareChallengeHeader(headers: Record<string, string> = {}): boolean {
   const cfMitigated = Object.entries(headers).find(([name]) => name.toLowerCase() === "cf-mitigated")?.[1]
   return cfMitigated?.toLowerCase() === "challenge"
@@ -18,16 +16,7 @@ export function hasCloudflareChallengeHeader(headers: Record<string, string> = {
 
 export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
   if (hasCloudflareChallengeHeader(headers)) return true
-  // Otherwise DDoS-Guard wins over the generic copy-text heuristics below: its
-  // interstitial says "Checking your browser before accessing", which they also match.
-  // This is an early return rather than ordering inside detectChallengeType() because
-  // tiers 3/4 call isCloudflarePage() directly for their persistence check.
-  if (hasDdosGuardChallenge(html, headers)) return false
-  // "ddos-guard" deliberately absent: DDoS-Guard is its own WAF with its own solve
-  // path (see hasDdosGuardChallenge / ddosGuardWait.ts). Matching it here routed it
-  // into the Cloudflare interstitial flow, which waits on cf_clearance and CF DOM
-  // markers that a DDoS-Guard page never emits — so it burned the whole timeout and
-  // then reported "cloudflare-persistent".
+  if (hasDdosGuardChallenge(html)) return false
   if (/<title>[^<]*(just a moment|please wait|checking|attention required)[^<]*<\/title>/i.test(html)) return true
   if (/checking your browser/i.test(html)) return true
   if (/enable javascript and cookies to continue/i.test(html)) return true
@@ -122,23 +111,9 @@ export function hasAkamaiChallenge(html: string, _headers: Record<string, string
   return false
 }
 
-// DDoS-Guard JS interstitial. The wall is a ~900-byte page that loads
-// /.well-known/ddos-guard/js-challenge/{index,view}.js plus check.ddos-guard.net/check.js,
-// shows "Checking your browser before accessing", and reloads into the real content once
-// the script has set the __ddg* cookies. A real browser executing real JS satisfies it
-// without challenge-specific logic, so — like Imperva — we detect the page and wait for
-// the cookie (see ddosGuardWait.ts).
-//
-// Every marker below is challenge-specific: the js-challenge asset paths, the
-// interstitial's own DOM ids, and its check.js. Deliberately NOT matched:
-//
-//   - `Server: ddos-guard` — present on every response DDoS-Guard fronts. Verified on
-//     annas-archive.gl, where the successful 200 and the 403 interstitial carry the
-//     identical header, so keying on it grades real content as a wall forever.
-//   - a bare `ddos-guard.net` mention — any page may link the provider. Size-gating it
-//     is not a fix: the gate is arbitrary, counts UTF-16 units rather than bytes, and
-//     still says nothing about the page being a challenge. The three markers above
-//     already cover the real interstitial (it carries all of them).
+// DDoS-Guard's JS interstitial markers. The provider's generic Server header and
+// bare domain mentions are intentionally excluded because ordinary protected pages
+// contain them too.
 export function hasDdosGuardChallenge(html: string, _headers: Record<string, string> = {}): boolean {
   if (/\/\.well-known\/ddos-guard\/js-challenge\//i.test(html)) return true
   if (/id=["']ddg-l10n-(title|description)["']|id=["']ddg-img-loading["']/i.test(html)) return true
@@ -147,14 +122,8 @@ export function hasDdosGuardChallenge(html: string, _headers: Record<string, str
 }
 
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
-  if (hasTurnstile(html)) return "cloudflare-turnstile"
-  // The authoritative CF header outranks the DDoS-Guard markers, so this agrees with
-  // isCloudflarePage() on a page fronted by both. Grading it ddos-guard here while
-  // isCloudflarePage() said cloudflare sent tiers 3/4 to the DDoS-Guard waiter and
-  // then judged the outcome with the Cloudflare persistence check.
   if (hasCloudflareChallengeHeader(headers)) return "cloudflare-interstitial"
-  // Otherwise DDoS-Guard precedes the Cloudflare check: its interstitial trips several
-  // of the generic copy-text heuristics inside isCloudflarePage().
+  if (hasTurnstile(html)) return "cloudflare-turnstile"
   if (hasDdosGuardChallenge(html, headers)) return "ddos-guard"
   if (isCloudflarePage(html, headers)) return "cloudflare-interstitial"
   if (hasImpervaChallenge(html, headers)) return "imperva"
@@ -191,7 +160,6 @@ export function needsJs(html: string, headers: Record<string, string>): boolean 
 const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
   "cloudflare-interstitial": 3000,
   imperva: 5000,
-  // The AA wall measured 902 bytes; give the same headroom CF gets.
   "ddos-guard": 3000,
 }
 

--- a/packages/tiers/tests/challengeRouter.test.ts
+++ b/packages/tiers/tests/challengeRouter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import type { Page } from "patchright"
+import { routeChallengeWait } from "../src/utils/challengeRouter"
+import { DDOS_GUARD_INTERSTITIAL } from "./fixtures/ddosGuard"
+
+describe("browser challenge routing", () => {
+  test("passes response headers into detection and routes an authoritative CF challenge to its waiter", async () => {
+    const calls: string[] = []
+    const waiter = (name: string) => async () => {
+      calls.push(name)
+      return "ok" as const
+    }
+    const result = await routeChallengeWait(
+      {} as Page,
+      DDOS_GUARD_INTERSTITIAL,
+      { "cf-mitigated": "challenge" },
+      100,
+      "https://example.test/",
+      {
+        cloudflare: waiter("cloudflare"),
+        ddosGuard: waiter("ddos-guard"),
+        imperva: waiter("imperva"),
+        akamai: waiter("akamai"),
+      },
+    )
+
+    expect(result.challengeType).toBe("cloudflare-interstitial")
+    expect(calls).toEqual(["cloudflare"])
+  })
+
+  test("routes DDoS-Guard markers to the dedicated waiter without the CF header", async () => {
+    const calls: string[] = []
+    const waiter = (name: string) => async () => {
+      calls.push(name)
+      return "ok" as const
+    }
+    const result = await routeChallengeWait({} as Page, DDOS_GUARD_INTERSTITIAL, {}, 100, undefined, {
+      cloudflare: waiter("cloudflare"),
+      ddosGuard: waiter("ddos-guard"),
+      imperva: waiter("imperva"),
+      akamai: waiter("akamai"),
+    })
+
+    expect(result.challengeType).toBe("ddos-guard")
+    expect(calls).toEqual(["ddos-guard"])
+  })
+})

--- a/packages/tiers/tests/ddosGuardDetection.test.ts
+++ b/packages/tiers/tests/ddosGuardDetection.test.ts
@@ -1,63 +1,36 @@
 import { describe, expect, test } from "bun:test"
-import { detectChallengeType, hasDdosGuardChallenge, isBlocked, isCloudflarePage, needsJs } from "../src/utils/detect"
-
-// Trimmed from a real DDoS-Guard interstitial (annas-archive.gl/search, HTTP 403, 902 bytes).
-const DDG_INTERSTITIAL = `<html><head><title>DDoS-Guard</title>
-<link rel="stylesheet" href="/.well-known/ddos-guard/js-challenge/index.css">
-<script defer src="/.well-known/ddos-guard/js-challenge/view.js"></script>
-<script defer src="/.well-known/ddos-guard/js-challenge/index.js"></script>
-<script src="https://check.ddos-guard.net/check.js"></script></head>
-<body><div id="ddg-img-loading"></div>
-<h1 id="ddg-l10n-title">Checking your browser before accessing <span class="ddg-origin"></span></h1>
-<p id="ddg-l10n-description">Please wait a few seconds. Once this check is complete, the website will open automatically</p>
-<div id="request-info"></div></body></html>`
+import {
+  detectChallengeType,
+  hasDdosGuardChallenge,
+  isBlocked,
+  isChallengeWall,
+  isCloudflarePage,
+  needsJs,
+} from "../src/utils/detect"
+import { DDOS_GUARD_INTERSTITIAL } from "./fixtures/ddosGuard"
 
 describe("DDoS-Guard detection", () => {
-  test("the interstitial is graded as ddos-guard, not cloudflare", () => {
-    expect(hasDdosGuardChallenge(DDG_INTERSTITIAL)).toBe(true)
-    expect(detectChallengeType(DDG_INTERSTITIAL)).toBe("ddos-guard")
-    // Regression: it used to match isCloudflarePage(), which routed it into the CF
-    // interstitial wait. That polls for cf_clearance and CF DOM markers a DDoS-Guard
-    // page never emits, so it consumed the whole timeout and reported
-    // "cloudflare-persistent". tiers 3/4 call isCloudflarePage() directly for their
-    // persistence check, so this must be false there too, not merely ordered later
-    // inside detectChallengeType().
-    expect(isCloudflarePage(DDG_INTERSTITIAL, {})).toBe(false)
+  test("classifies a real interstitial independently from Cloudflare", () => {
+    expect(hasDdosGuardChallenge(DDOS_GUARD_INTERSTITIAL)).toBe(true)
+    expect(detectChallengeType(DDOS_GUARD_INTERSTITIAL)).toBe("ddos-guard")
+    expect(isCloudflarePage(DDOS_GUARD_INTERSTITIAL, {})).toBe(false)
+    expect(needsJs(DDOS_GUARD_INTERSTITIAL, {})).toBe(true)
+    expect(isBlocked(200, DDOS_GUARD_INTERSTITIAL)).toBe(true)
+    expect(isChallengeWall(200, DDOS_GUARD_INTERSTITIAL.length, "ddos-guard")).toBe(true)
   })
 
-  test("the interstitial still counts as blocked and as needing JS", () => {
-    expect(isBlocked(403, DDG_INTERSTITIAL)).toBe(true)
-    expect(needsJs(DDG_INTERSTITIAL, {})).toBe(true)
+  test("does not classify an ordinary page from a DDoS-Guard-fronted server", () => {
+    const html = "<html><title>Books</title><body>Search results</body></html>"
+    expect(detectChallengeType(html, { Server: "ddos-guard" })).toBe("none")
   })
 
-  test("a real page from a DDoS-Guard-fronted site is not a challenge", () => {
-    // DDoS-Guard sets `Server: ddos-guard` on every response it fronts — verified on
-    // annas-archive.gl, where the 200 and the 403 interstitial carry the identical
-    // header. Detection must not key off it, or every successful page from such a
-    // site is graded a wall and sent back through the solver forever.
-    const realPage = `<html><head><title>Search results</title></head><body>${"<a href='/md5/abc'>book</a>".repeat(200)}</body></html>`
-    expect(hasDdosGuardChallenge(realPage, { server: "ddos-guard" })).toBe(false)
-    expect(detectChallengeType(realPage, { server: "ddos-guard" })).toBe("none")
-    expect(isBlocked(200, realPage)).toBe(false)
+  test("does not classify a bare provider-domain mention", () => {
+    expect(detectChallengeType("<p>Protected by ddos-guard.net</p>")).toBe("none")
   })
 
-  test("merely mentioning ddos-guard.net is not a challenge, at any size", () => {
-    // Detection requires challenge-specific evidence (asset paths, DOM ids, check.js).
-    // A bare provider mention is not evidence, and a size gate would not make it so.
-    const small = `<html><body><p>Protected by ddos-guard.net</p></body></html>`
-    const big = `<html><body><p>Protected by ddos-guard.net</p>${"x".repeat(5000)}</body></html>`
-    expect(hasDdosGuardChallenge(small)).toBe(false)
-    expect(hasDdosGuardChallenge(big)).toBe(false)
-  })
-
-  test("an authoritative cf-mitigated header wins over DDoS-Guard markers, consistently", () => {
-    // A page fronted by both must be graded Cloudflare — the CF header is definitive,
-    // the DDoS-Guard markers are heuristics. Both entry points must agree: an earlier
-    // cut had isCloudflarePage() say cloudflare while detectChallengeType() said
-    // ddos-guard, which sent tiers 3/4 to the DDoS-Guard waiter and then judged the
-    // outcome with the Cloudflare persistence check.
-    const cfHeaders = { "cf-mitigated": "challenge" }
-    expect(isCloudflarePage(DDG_INTERSTITIAL, cfHeaders)).toBe(true)
-    expect(detectChallengeType(DDG_INTERSTITIAL, cfHeaders)).toBe("cloudflare-interstitial")
+  test("lets the authoritative Cloudflare header win", () => {
+    const headers = { "CF-Mitigated": "Challenge" }
+    expect(detectChallengeType(DDOS_GUARD_INTERSTITIAL, headers)).toBe("cloudflare-interstitial")
+    expect(isCloudflarePage(DDOS_GUARD_INTERSTITIAL, headers)).toBe(true)
   })
 })

--- a/packages/tiers/tests/ddosGuardDetection.test.ts
+++ b/packages/tiers/tests/ddosGuardDetection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { detectChallengeType, hasDdosGuardChallenge, isBlocked, isCloudflarePage, needsJs } from "../src/utils/detect"
+
+// Trimmed from a real DDoS-Guard interstitial (annas-archive.gl/search, HTTP 403, 902 bytes).
+const DDG_INTERSTITIAL = `<html><head><title>DDoS-Guard</title>
+<link rel="stylesheet" href="/.well-known/ddos-guard/js-challenge/index.css">
+<script defer src="/.well-known/ddos-guard/js-challenge/view.js"></script>
+<script defer src="/.well-known/ddos-guard/js-challenge/index.js"></script>
+<script src="https://check.ddos-guard.net/check.js"></script></head>
+<body><div id="ddg-img-loading"></div>
+<h1 id="ddg-l10n-title">Checking your browser before accessing <span class="ddg-origin"></span></h1>
+<p id="ddg-l10n-description">Please wait a few seconds. Once this check is complete, the website will open automatically</p>
+<div id="request-info"></div></body></html>`
+
+describe("DDoS-Guard detection", () => {
+  test("the interstitial is graded as ddos-guard, not cloudflare", () => {
+    expect(hasDdosGuardChallenge(DDG_INTERSTITIAL)).toBe(true)
+    expect(detectChallengeType(DDG_INTERSTITIAL)).toBe("ddos-guard")
+    // Regression: it used to match isCloudflarePage(), which routed it into the CF
+    // interstitial wait. That polls for cf_clearance and CF DOM markers a DDoS-Guard
+    // page never emits, so it consumed the whole timeout and reported
+    // "cloudflare-persistent". tiers 3/4 call isCloudflarePage() directly for their
+    // persistence check, so this must be false there too, not merely ordered later
+    // inside detectChallengeType().
+    expect(isCloudflarePage(DDG_INTERSTITIAL, {})).toBe(false)
+  })
+
+  test("the interstitial still counts as blocked and as needing JS", () => {
+    expect(isBlocked(403, DDG_INTERSTITIAL)).toBe(true)
+    expect(needsJs(DDG_INTERSTITIAL, {})).toBe(true)
+  })
+
+  test("a real page from a DDoS-Guard-fronted site is not a challenge", () => {
+    // DDoS-Guard sets `Server: ddos-guard` on every response it fronts — verified on
+    // annas-archive.gl, where the 200 and the 403 interstitial carry the identical
+    // header. Detection must not key off it, or every successful page from such a
+    // site is graded a wall and sent back through the solver forever.
+    const realPage = `<html><head><title>Search results</title></head><body>${"<a href='/md5/abc'>book</a>".repeat(200)}</body></html>`
+    expect(hasDdosGuardChallenge(realPage, { server: "ddos-guard" })).toBe(false)
+    expect(detectChallengeType(realPage, { server: "ddos-guard" })).toBe("none")
+    expect(isBlocked(200, realPage)).toBe(false)
+  })
+
+  test("merely mentioning ddos-guard.net is not a challenge, at any size", () => {
+    // Detection requires challenge-specific evidence (asset paths, DOM ids, check.js).
+    // A bare provider mention is not evidence, and a size gate would not make it so.
+    const small = `<html><body><p>Protected by ddos-guard.net</p></body></html>`
+    const big = `<html><body><p>Protected by ddos-guard.net</p>${"x".repeat(5000)}</body></html>`
+    expect(hasDdosGuardChallenge(small)).toBe(false)
+    expect(hasDdosGuardChallenge(big)).toBe(false)
+  })
+
+  test("an authoritative cf-mitigated header wins over DDoS-Guard markers, consistently", () => {
+    // A page fronted by both must be graded Cloudflare — the CF header is definitive,
+    // the DDoS-Guard markers are heuristics. Both entry points must agree: an earlier
+    // cut had isCloudflarePage() say cloudflare while detectChallengeType() said
+    // ddos-guard, which sent tiers 3/4 to the DDoS-Guard waiter and then judged the
+    // outcome with the Cloudflare persistence check.
+    const cfHeaders = { "cf-mitigated": "challenge" }
+    expect(isCloudflarePage(DDG_INTERSTITIAL, cfHeaders)).toBe(true)
+    expect(detectChallengeType(DDG_INTERSTITIAL, cfHeaders)).toBe("cloudflare-interstitial")
+  })
+})

--- a/packages/tiers/tests/ddosGuardWait.test.ts
+++ b/packages/tiers/tests/ddosGuardWait.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import type { Page } from "patchright"
+import { waitForDdosGuardResolution } from "../src/utils/ddosGuardWait"
+import { DDOS_GUARD_INTERSTITIAL } from "./fixtures/ddosGuard"
+
+const REAL_PAGE = "<html><body>real content</body></html>"
+
+function pageMock(options: {
+  html?: string
+  cookies?: Array<{ name: string; domain: string }>
+  onGoto?: () => void
+  content?: () => Promise<string>
+}) {
+  let html = options.html ?? DDOS_GUARD_INTERSTITIAL
+  const page = {
+    url: () => "https://example.test/",
+    content: options.content ?? (async () => html),
+    context: () => ({ cookies: async () => options.cookies ?? [] }),
+    goto: async () => {
+      options.onGoto?.()
+      if (options.onGoto === undefined) html = REAL_PAGE
+      return null
+    },
+    waitForLoadState: async () => {},
+  }
+  return { page: page as unknown as Page, setHtml: (value: string) => (html = value) }
+}
+
+const FAST_WAIT = { pollMs: 2, renavigationGraceMs: 0, renavigationIntervalMs: 0 }
+
+describe("DDoS-Guard waiter", () => {
+  test("returns ok when the interstitial clears itself", async () => {
+    let reads = 0
+    const { page } = pageMock({
+      content: async () => (++reads === 1 ? DDOS_GUARD_INTERSTITIAL : REAL_PAGE),
+    })
+    expect(await waitForDdosGuardResolution(page, 100, undefined, FAST_WAIT)).toBe("ok")
+  })
+
+  test("uses a clearance cookie to re-navigate and verifies the resulting document", async () => {
+    const { page } = pageMock({ cookies: [{ name: "__ddg2_abc", domain: ".example.test" }] })
+    expect(await waitForDdosGuardResolution(page, 100, "https://example.test/", FAST_WAIT)).toBe("ok")
+  })
+
+  test("returns ip-blocked after a bounded number of persistent re-navigations", async () => {
+    const { page } = pageMock({
+      cookies: [{ name: "__ddg5_abc", domain: "example.test" }],
+      onGoto: () => {},
+    })
+    expect(await waitForDdosGuardResolution(page, 200, "https://example.test/", FAST_WAIT)).toBe("ip-blocked")
+  })
+
+  test("times out when no clearance appears", async () => {
+    expect(await waitForDdosGuardResolution(pageMock({}).page, 20, undefined, FAST_WAIT)).toBe("timeout")
+  })
+
+  test("never treats empty or stuck content as solved and stays within budget", async () => {
+    for (const content of [async () => "", () => new Promise<string>(() => {})]) {
+      const start = Date.now()
+      const result = await waitForDdosGuardResolution(pageMock({ content }).page, 25, undefined, FAST_WAIT)
+      expect(result).toBe("timeout")
+      expect(Date.now() - start).toBeLessThan(75)
+    }
+  })
+
+  test("immediately rejects an exhausted budget", async () => {
+    const start = Date.now()
+    expect(await waitForDdosGuardResolution(pageMock({}).page, 0)).toBe("timeout")
+    expect(Date.now() - start).toBeLessThan(20)
+  })
+})

--- a/packages/tiers/tests/fixtures/ddosGuard.ts
+++ b/packages/tiers/tests/fixtures/ddosGuard.ts
@@ -1,0 +1,6 @@
+export const DDOS_GUARD_INTERSTITIAL = `<html><head><title>DDoS-Guard</title>
+<link rel="stylesheet" href="/.well-known/ddos-guard/js-challenge/index.css">
+<script defer src="/.well-known/ddos-guard/js-challenge/view.js"></script>
+<script src="https://check.ddos-guard.net/check.js"></script></head>
+<body><div id="ddg-img-loading"></div><h1 id="ddg-l10n-title">Checking your browser</h1>
+<p id="ddg-l10n-description">Please wait</p></body></html>`

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trawl/types",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",


### PR DESCRIPTION
## Summary

Give DDoS-Guard its own challenge detection and browser waiter instead of routing its interstitial through Cloudflare handling. Harden the waiter around request deadlines, stalled browser operations, clearance-cookie re-navigation, persistent walls, Tier 3/4 routing, and proxy classification, then prepare the fix for v1.4.2.

The original contribution from #66 remains in the branch history, followed by the additional hardening and release preparation.

## Linked issues

n/a — follows up on #66.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [ ] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).