### PR TITLE
fix(api): reap orphaned Camoufox processes with Tini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
+
 ## [1.4.2] - 2026-08-22
 
 ### Changed

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       fonts-liberation \
       ca-certificates \
       curl \
+      tini \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /usr/share/locale /usr/share/doc /usr/share/man
 
@@ -160,4 +161,5 @@ ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox \
 
 WORKDIR /app
 EXPOSE 8191
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["bun", "run", "apps/api/src/index.ts"]

--- a/apps/api/Dockerfile.baseline
+++ b/apps/api/Dockerfile.baseline
@@ -122,7 +122,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libdrm2 libgbm1 \
       libasound2 \
       fonts-liberation \
-      ca-certificates unzip curl \
+      ca-certificates unzip curl tini \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /usr/share/locale /usr/share/doc /usr/share/man
 
@@ -178,4 +178,5 @@ ENV CAMOUFOX_INSTALL_DIR=/opt/camoufox \
 
 WORKDIR /app
 EXPOSE 8191
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["bun", "run", "apps/api/src/index.ts"]


### PR DESCRIPTION
## Summary

Adds Tini as PID 1 to both API container variants so orphaned Camoufox subprocesses are reaped instead of accumulating as zombies. Bun remains the application command and continues to receive shutdown signals normally.

## Linked issues

Fixes #79 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [ ] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE)