### PR TITLE
fix(proxy): preserve multiple Set-Cookie headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
-- **Proxy: malformed `Set-Cookie` headers for Go and other strict HTTP/1.1 clients.** Playwright's `response.allHeaders()` joins multiple `Set-Cookie` values with `\n` into a single map entry. `writeResponseFromBuffer` was emitting that string as one header line with embedded newlines, which Go's `net/http` parser (and other strict clients) rejected as a malformed MIME header line — in particular when an `Expires` date containing a comma appeared after the fold. The fix splits on `\n` and emits each cookie as its own `Set-Cookie:` header line, as required by RFC 6265.
+- Preserve every upstream `Set-Cookie` field across direct, Tier 1, and browser-backed proxy responses, serializing each cookie as its own HTTP header instead of dropping or malformedly folding repeated values (#64).
 
 ## [1.4.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Proxy: malformed `Set-Cookie` headers for Go and other strict HTTP/1.1 clients.** Playwright's `response.allHeaders()` joins multiple `Set-Cookie` values with `\n` into a single map entry. `writeResponseFromBuffer` was emitting that string as one header line with embedded newlines, which Go's `net/http` parser (and other strict clients) rejected as a malformed MIME header line — in particular when an `Expires` date containing a comma appeared after the fold. The fix splits on `\n` and emits each cookie as its own `Set-Cookie:` header line, as required by RFC 6265.
+
 ## [1.4.0] - 2026-08-10
 
 ### Changed

--- a/apps/api/src/proxy/__tests__/directForward.test.ts
+++ b/apps/api/src/proxy/__tests__/directForward.test.ts
@@ -16,6 +16,18 @@ const chunked = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
 
 const fetchFixture = (req: Request): Response => {
   const { pathname } = new URL(req.url)
+  if (pathname === "/cookies") {
+    const headers = new Headers({ "Content-Type": "text/html" })
+    headers.append("Set-Cookie", "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/")
+    headers.append("Set-Cookie", "clearance=two; Path=/; HttpOnly")
+    return new Response("cookies", { headers })
+  }
+  if (pathname === "/cookie-video") {
+    const headers = new Headers({ "Content-Type": "video/mp4" })
+    headers.append("Set-Cookie", "session=one; Path=/")
+    headers.append("Set-Cookie", "clearance=two; Path=/; Secure")
+    return new Response(Buffer.from([0, 1, 2, 3]), { headers })
+  }
   if (pathname === "/chunked-html")
     return new Response(
       chunked(Buffer.from("<!doctype html><title>Normal page</title>"), Buffer.from("<p>small response</p>")),
@@ -139,6 +151,23 @@ describe("directForwardHttp — Range / 206 Partial Content", () => {
 })
 
 describe("directForwardHttp — buffered by default", () => {
+  test("preserves repeated Set-Cookie fields using the internal newline convention", async () => {
+    const result = await directForwardHttp({ url: `${baseUrl}/cookies`, method: "GET", headers: {} })
+    expect(result.mode).toBe("buffer")
+    if (result.mode !== "buffer") return
+    expect(result.headers["set-cookie"]).toBe(
+      "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/\nclearance=two; Path=/; HttpOnly",
+    )
+  })
+
+  test("preserves repeated Set-Cookie fields on streamed responses", async () => {
+    const result = await directForwardHttp({ url: `${baseUrl}/cookie-video`, method: "GET", headers: {} })
+    expect(result.mode).toBe("stream")
+    if (result.mode !== "stream") return
+    expect(result.headers["set-cookie"]).toBe("session=one; Path=/\nclearance=two; Path=/; Secure")
+    result.socket.destroy()
+  })
+
   test("skips 103 Early Hints and escalates cf-mitigated without waiting for an open body", async () => {
     const sockets = new Set<net.Socket>()
     const hangingServer = net.createServer((socket) => {

--- a/apps/api/src/proxy/__tests__/httpResponse.test.ts
+++ b/apps/api/src/proxy/__tests__/httpResponse.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { once } from "node:events"
+import http from "node:http"
+import net from "node:net"
+import { serializeResponseHeaders } from "../httpResponse"
+
+describe("proxy response serialization", () => {
+  test.each([false, true])("emits each cookie as a valid field for streamed=%s", (streamed) => {
+    const head = serializeResponseHeaders(
+      200,
+      {
+        "content-type": "text/html",
+        "set-cookie": "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/\n \nclearance=two; Path=/; HttpOnly",
+      },
+      "application/octet-stream",
+      streamed ? { streamed: true } : { bodyLength: 0 },
+    )
+    const lines = head.split("\r\n")
+    expect(lines.filter((line) => line.toLowerCase().startsWith("set-cookie:"))).toEqual([
+      "set-cookie: session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/",
+      "set-cookie: clearance=two; Path=/; HttpOnly",
+    ])
+    expect(lines).not.toContain("clearance=two; Path=/; HttpOnly")
+  })
+
+  test("leaves a single cookie unchanged", () => {
+    const head = serializeResponseHeaders(200, { "set-cookie": "session=one; Path=/" }, "text/plain", {
+      bodyLength: 0,
+    })
+    expect(head.match(/set-cookie:/gi)).toHaveLength(1)
+    expect(head).toContain("set-cookie: session=one; Path=/\r\n")
+  })
+
+  test("is accepted by a strict HTTP parser as two separate cookie fields", async () => {
+    const body = Buffer.from("ok")
+    const head = serializeResponseHeaders(
+      200,
+      {
+        "content-type": "text/plain",
+        "set-cookie": "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/\r\nclearance=two; Path=/; Secure",
+      },
+      "text/plain",
+      { bodyLength: body.length },
+    )
+    const server = net.createServer((socket) => {
+      socket.once("data", () => socket.end(Buffer.concat([Buffer.from(head), body])))
+    })
+    server.listen(0, "127.0.0.1")
+    await once(server, "listening")
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("test server did not bind")
+
+    try {
+      const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        http.get({ host: "127.0.0.1", port: address.port, path: "/" }, resolve).once("error", reject)
+      })
+      response.resume()
+      await once(response, "end")
+      expect(response.headers["set-cookie"]).toEqual([
+        "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/",
+        "clearance=two; Path=/; Secure",
+      ])
+      expect(response.rawHeaders.filter((header) => header.toLowerCase() === "set-cookie")).toHaveLength(2)
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+})

--- a/apps/api/src/proxy/__tests__/server.test.ts
+++ b/apps/api/src/proxy/__tests__/server.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import type net from "node:net"
+import { PassThrough } from "node:stream"
+import { writeResponseFromBuffer } from "../httpResponse"
+
+describe("writeResponseFromBuffer — Set-Cookie newline folding", () => {
+  test("emits one Set-Cookie line per cookie when Playwright newline-folds them", () => {
+    // Playwright's response.allHeaders() joins multiple Set-Cookie values with \n.
+    // A bare value after the fold creates a 'malformed MIME header line' error in
+    // strict HTTP/1.1 clients (e.g. Go's net/http) when the Expires date contains
+    // a comma.
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    const cookieA = "session-id=abc; Domain=.example.com; Path=/; Secure"
+    const cookieB =
+      "session-id-time=123456789l; Domain=.example.com; Expires=Tue, 01 Jan 2030 00:00:00 GMT; Path=/; Secure"
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": `${cookieA}\n${cookieB}`, "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+
+    // Must produce two separate header lines, not one line with an embedded newline.
+    expect(cookieLines).toHaveLength(2)
+    expect(cookieLines[0]).toContain("session-id=abc")
+    expect(cookieLines[1]).toContain("session-id-time=")
+
+    // No bare continuation line — the Expires comma must not produce a split.
+    const malformed = lines.filter((l) => /^session-id-time=/.test(l))
+    expect(malformed).toHaveLength(0)
+  })
+
+  test("passes through a single-value Set-Cookie header unchanged", () => {
+    const stream = new PassThrough()
+    const chunks: Buffer[] = []
+    stream.on("data", (c: Buffer) => chunks.push(c))
+
+    writeResponseFromBuffer(
+      stream as unknown as net.Socket,
+      200,
+      { "set-cookie": "token=xyz; Path=/; HttpOnly", "content-type": "text/html" },
+      Buffer.from("ok"),
+      "text/html",
+    )
+
+    const raw = Buffer.concat(chunks).toString("latin1")
+    const lines = raw.split("\r\n")
+    const cookieLines = lines.filter((l) => l.toLowerCase().startsWith("set-cookie:"))
+    expect(cookieLines).toHaveLength(1)
+    expect(cookieLines[0]).toContain("token=xyz")
+  })
+})

--- a/apps/api/src/proxy/directForward.ts
+++ b/apps/api/src/proxy/directForward.ts
@@ -224,10 +224,11 @@ async function readHttpResponse(
     const name = line.slice(0, idx).trim().toLowerCase()
     const value = line.slice(idx + 1).trim()
     if (!name) continue
-    // Keep first occurrence for multi-value headers; Set-Cookie is the
-    // common case where only the first makes it through. Caller can read
-    // raw lines via the set-cookie header if needed.
-    if (headers[name] === undefined) headers[name] = value
+    if (name === "set-cookie" && headers[name] !== undefined) {
+      headers[name] += `\n${value}`
+    } else if (headers[name] === undefined) {
+      headers[name] = value
+    }
   }
 
   const contentType = headers["content-type"] ?? "application/octet-stream"

--- a/apps/api/src/proxy/httpResponse.ts
+++ b/apps/api/src/proxy/httpResponse.ts
@@ -1,0 +1,114 @@
+// Lightweight HTTP/1.1 response serialization helpers.
+// Kept separate from server.ts so unit tests can import without loading
+// the proxy server's heavy dependency chain (browser pool, scrape tiers).
+
+import net from "node:net"
+
+// RFC 7230 §6.1 hop-by-hop headers — must stay in sync with packages/tiers/src/utils/sanitize.ts.
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+
+function reason(status: number): string {
+  const map: Record<number, string> = {
+    200: "OK",
+    403: "Forbidden",
+    404: "Not Found",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+  }
+  return map[status] ?? "OK"
+}
+
+export function writeResponse(
+  sock: net.Socket,
+  status: number,
+  body: Buffer,
+  contentType = "text/html; charset=utf-8",
+): void {
+  const head =
+    `HTTP/1.1 ${status} ${reason(status)}\r\n` +
+    `Content-Type: ${contentType}\r\n` +
+    `Content-Length: ${body.length}\r\n` +
+    "Connection: close\r\n\r\n"
+  sock.write(head)
+  sock.write(body)
+  sock.end()
+}
+
+// Buffered responses preserve end-to-end headers and derive a fresh body length.
+export function writeResponseFromBuffer(
+  sock: net.Socket,
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  body: Buffer,
+  fallbackContentType: string,
+): void {
+  const ct = upstreamHeaders["content-type"] ?? fallbackContentType
+  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
+  let emittedContentType = false
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const lower = name.toLowerCase()
+    if (HOP_BY_HOP.has(lower)) continue
+    if (lower === "content-length") continue
+    if (lower === "content-type") emittedContentType = true
+    // Playwright joins multiple Set-Cookie values with \n into one map entry.
+    // Emit each cookie as its own header line — RFC 6265 forbids comma-folding.
+    if (lower === "set-cookie") {
+      for (const cookie of value.split(/\r?\n/)) {
+        const trimmed = cookie.trim()
+        if (trimmed) headerLines.push(`${name}: ${trimmed}`)
+      }
+      continue
+    }
+    headerLines.push(`${name}: ${value}`)
+  }
+  if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)
+  headerLines.push(`Content-Length: ${body.length}`)
+  headerLines.push("Connection: close")
+  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  sock.write(body)
+  sock.end()
+}
+
+// Streamed responses retain upstream transfer framing.
+export function writeResponseFromStream(
+  sock: net.Socket,
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  upstreamSocket: net.Socket,
+  fallbackContentType: string,
+  requestBodyLength: number,
+  prefix?: Buffer,
+): void {
+  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
+  let emittedContentType = false
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const lower = name.toLowerCase()
+    // The streamed bytes retain upstream HTTP/1.1 chunk framing, so preserve
+    // Transfer-Encoding. Other hop-by-hop headers remain connection-local.
+    if (HOP_BY_HOP.has(lower) && lower !== "transfer-encoding") continue
+    if (lower === "content-type") emittedContentType = true
+    headerLines.push(`${name}: ${value}`)
+  }
+  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
+  if (requestBodyLength > 0) headerLines.push(`X-Forwarded-Body-Length: ${requestBodyLength}`)
+  headerLines.push("Connection: close")
+  // Write HTTP headers first, then prefix body bytes (which arrived in the same
+  // TCP segment as upstream's response headers), then pipe the rest of the body.
+  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  if (prefix?.length) sock.write(prefix)
+  upstreamSocket.pipe(sock)
+  sock.on("error", () => upstreamSocket.destroy())
+  upstreamSocket.on("error", () => sock.destroy())
+  upstreamSocket.on("end", () => sock.end())
+  upstreamSocket.on("close", () => sock.end())
+}

--- a/apps/api/src/proxy/httpResponse.ts
+++ b/apps/api/src/proxy/httpResponse.ts
@@ -1,21 +1,5 @@
-// Lightweight HTTP/1.1 response serialization helpers.
-// Kept separate from server.ts so unit tests can import without loading
-// the proxy server's heavy dependency chain (browser pool, scrape tiers).
-
-import net from "node:net"
-
-// RFC 7230 §6.1 hop-by-hop headers — must stay in sync with packages/tiers/src/utils/sanitize.ts.
-const HOP_BY_HOP = new Set([
-  "connection",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "proxy-connection",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-])
+import type net from "node:net"
+import { RESPONSE_HOP_BY_HOP_HEADERS } from "@trawl/tiers"
 
 function reason(status: number): string {
   const map: Record<number, string> = {
@@ -26,6 +10,38 @@ function reason(status: number): string {
     502: "Bad Gateway",
   }
   return map[status] ?? "OK"
+}
+
+function appendHeader(headerLines: string[], name: string, value: string): void {
+  if (name.toLowerCase() !== "set-cookie") {
+    headerLines.push(`${name}: ${value}`)
+    return
+  }
+  for (const cookie of value.split(/\r?\n/)) {
+    if (cookie.trim().length > 0) headerLines.push(`${name}: ${cookie}`)
+  }
+}
+
+export function serializeResponseHeaders(
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  fallbackContentType: string,
+  options: { bodyLength?: number; streamed?: boolean; requestBodyLength?: number } = {},
+): string {
+  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
+  let emittedContentType = false
+  for (const [name, value] of Object.entries(upstreamHeaders)) {
+    const lower = name.toLowerCase()
+    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower) && !(options.streamed && lower === "transfer-encoding")) continue
+    if (!options.streamed && lower === "content-length") continue
+    if (lower === "content-type") emittedContentType = true
+    appendHeader(headerLines, name, value)
+  }
+  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
+  if (options.bodyLength !== undefined) headerLines.push(`Content-Length: ${options.bodyLength}`)
+  if ((options.requestBodyLength ?? 0) > 0) headerLines.push(`X-Forwarded-Body-Length: ${options.requestBodyLength}`)
+  headerLines.push("Connection: close")
+  return `${headerLines.join("\r\n")}\r\n\r\n`
 }
 
 export function writeResponse(
@@ -44,7 +60,6 @@ export function writeResponse(
   sock.end()
 }
 
-// Buffered responses preserve end-to-end headers and derive a fresh body length.
 export function writeResponseFromBuffer(
   sock: net.Socket,
   status: number,
@@ -52,34 +67,11 @@ export function writeResponseFromBuffer(
   body: Buffer,
   fallbackContentType: string,
 ): void {
-  const ct = upstreamHeaders["content-type"] ?? fallbackContentType
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    if (HOP_BY_HOP.has(lower)) continue
-    if (lower === "content-length") continue
-    if (lower === "content-type") emittedContentType = true
-    // Playwright joins multiple Set-Cookie values with \n into one map entry.
-    // Emit each cookie as its own header line — RFC 6265 forbids comma-folding.
-    if (lower === "set-cookie") {
-      for (const cookie of value.split(/\r?\n/)) {
-        const trimmed = cookie.trim()
-        if (trimmed) headerLines.push(`${name}: ${trimmed}`)
-      }
-      continue
-    }
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)
-  headerLines.push(`Content-Length: ${body.length}`)
-  headerLines.push("Connection: close")
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  sock.write(serializeResponseHeaders(status, upstreamHeaders, fallbackContentType, { bodyLength: body.length }))
   sock.write(body)
   sock.end()
 }
 
-// Streamed responses retain upstream transfer framing.
 export function writeResponseFromStream(
   sock: net.Socket,
   status: number,
@@ -89,22 +81,9 @@ export function writeResponseFromStream(
   requestBodyLength: number,
   prefix?: Buffer,
 ): void {
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    // The streamed bytes retain upstream HTTP/1.1 chunk framing, so preserve
-    // Transfer-Encoding. Other hop-by-hop headers remain connection-local.
-    if (HOP_BY_HOP.has(lower) && lower !== "transfer-encoding") continue
-    if (lower === "content-type") emittedContentType = true
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
-  if (requestBodyLength > 0) headerLines.push(`X-Forwarded-Body-Length: ${requestBodyLength}`)
-  headerLines.push("Connection: close")
-  // Write HTTP headers first, then prefix body bytes (which arrived in the same
-  // TCP segment as upstream's response headers), then pipe the rest of the body.
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
+  sock.write(
+    serializeResponseHeaders(status, upstreamHeaders, fallbackContentType, { streamed: true, requestBodyLength }),
+  )
   if (prefix?.length) sock.write(prefix)
   upstreamSocket.pipe(sock)
   sock.on("error", () => upstreamSocket.destroy())

--- a/apps/api/src/proxy/server.ts
+++ b/apps/api/src/proxy/server.ts
@@ -10,6 +10,7 @@ import {
 import { MitmCa } from "./ca"
 import { ChallengeCache } from "./challengeCache"
 import { directForwardHttp, directForwardHttps, type ForwardResult } from "./directForward"
+import { writeResponse, writeResponseFromBuffer, writeResponseFromStream } from "./httpResponse"
 import { responseFromScrapeResult } from "./responsePolicy"
 
 // General forward proxy with browser-backed challenge escalation. HTTPS is
@@ -535,77 +536,6 @@ async function handlePlainHttp(clientSocket: net.Socket, first: Buffer, opts: Mi
   })
 }
 
-function writeResponse(sock: net.Socket, status: number, body: Buffer, contentType = "text/html; charset=utf-8"): void {
-  const head =
-    `HTTP/1.1 ${status} ${reason(status)}\r\n` +
-    `Content-Type: ${contentType}\r\n` +
-    `Content-Length: ${body.length}\r\n` +
-    "Connection: close\r\n\r\n"
-  sock.write(head)
-  sock.write(body)
-  sock.end()
-}
-
-// Buffered responses preserve end-to-end headers and derive a fresh body length.
-function writeResponseFromBuffer(
-  sock: net.Socket,
-  status: number,
-  upstreamHeaders: Record<string, string>,
-  body: Buffer,
-  fallbackContentType: string,
-): void {
-  const ct = upstreamHeaders["content-type"] ?? fallbackContentType
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower)) continue
-    if (lower === "content-length") continue
-    if (lower === "content-type") emittedContentType = true
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${ct}`)
-  headerLines.push(`Content-Length: ${body.length}`)
-  headerLines.push("Connection: close")
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
-  sock.write(body)
-  sock.end()
-}
-
-// Streamed responses retain upstream transfer framing.
-function writeResponseFromStream(
-  sock: net.Socket,
-  status: number,
-  upstreamHeaders: Record<string, string>,
-  upstreamSocket: net.Socket,
-  fallbackContentType: string,
-  requestBodyLength: number,
-  prefix?: Buffer,
-): void {
-  const headerLines: string[] = [`HTTP/1.1 ${status} ${reason(status)}`]
-  let emittedContentType = false
-  for (const [name, value] of Object.entries(upstreamHeaders)) {
-    const lower = name.toLowerCase()
-    // The streamed bytes retain upstream HTTP/1.1 chunk framing, so preserve
-    // Transfer-Encoding. Other hop-by-hop headers remain connection-local.
-    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lower) && lower !== "transfer-encoding") continue
-    if (lower === "content-type") emittedContentType = true
-    headerLines.push(`${name}: ${value}`)
-  }
-  if (!emittedContentType) headerLines.push(`Content-Type: ${fallbackContentType}`)
-  if (requestBodyLength > 0) headerLines.push(`X-Forwarded-Body-Length: ${requestBodyLength}`)
-  headerLines.push("Connection: close")
-  // Write HTTP headers first, then prefix body bytes (which arrived in the same
-  // TCP segment as upstream's response headers), then pipe the rest of the body.
-  sock.write(`${headerLines.join("\r\n")}\r\n\r\n`)
-  if (prefix?.length) sock.write(prefix)
-  upstreamSocket.pipe(sock)
-  sock.on("error", () => upstreamSocket.destroy())
-  upstreamSocket.on("error", () => sock.destroy())
-  upstreamSocket.on("end", () => sock.end())
-  upstreamSocket.on("close", () => sock.end())
-}
-
 function parseHeaders(lines: string[]): Record<string, string> {
   const out: Record<string, string> = {}
   for (const line of lines) {
@@ -613,15 +543,4 @@ function parseHeaders(lines: string[]): Record<string, string> {
     if (idx > 0) out[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim()
   }
   return out
-}
-
-function reason(status: number): string {
-  const map: Record<number, string> = {
-    200: "OK",
-    403: "Forbidden",
-    404: "Not Found",
-    500: "Internal Server Error",
-    502: "Bad Gateway",
-  }
-  return map[status] ?? "OK"
 }

--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -57,6 +57,8 @@ export async function runTier1(
     res.headers.forEach((v, k) => {
       responseHeaders[k] = v
     })
+    const setCookies = res.headers.getSetCookie()
+    if (setCookies.length > 0) responseHeaders["set-cookie"] = setCookies.join("\n")
     const contentType = responseHeaders["content-type"] ?? "application/octet-stream"
 
     // Decode a bounded preview losslessly for challenge detection — keeps the original

--- a/packages/tiers/src/utils/response.ts
+++ b/packages/tiers/src/utils/response.ts
@@ -2,6 +2,7 @@ export interface MinimalResponse {
   url(): string
   status(): number
   headers(): Record<string, string>
+  allHeaders(): Promise<Record<string, string>>
   body(): Promise<Buffer | Uint8Array>
 }
 
@@ -22,7 +23,7 @@ export const captureResponse = async (response?: MinimalResponse): Promise<Captu
   if (!response) return {}
   try {
     const raw = await response.body()
-    const responseHeaders = response.headers()
+    const responseHeaders = await response.allHeaders()
     return {
       body: raw instanceof Uint8Array ? raw : new Uint8Array(raw),
       responseHeaders,

--- a/packages/tiers/tests/mainResponse.test.ts
+++ b/packages/tiers/tests/mainResponse.test.ts
@@ -11,12 +11,13 @@ function response(
   status: number,
   headers: Record<string, string>,
   body: string,
-  options: { navigation?: boolean; frame?: object } = {},
+  options: { navigation?: boolean; frame?: object; allHeaders?: Record<string, string> } = {},
 ) {
   return {
     url: () => url,
     status: () => status,
     headers: () => headers,
+    allHeaders: async () => options.allHeaders ?? headers,
     body: async () => Buffer.from(body),
     request: () => ({
       isNavigationRequest: () => options.navigation ?? true,
@@ -58,5 +59,23 @@ describe("MainDocumentResponseTracker", () => {
 
     expect(tracker.status).toBe(301)
     expect(tracker.headers.location).toBe("magnet:?xt=urn:test")
+  })
+
+  test("captures cookie headers from allHeaders even when headers omits them", async () => {
+    const tracker = new MainDocumentResponseTracker(page as never)
+    tracker.observe(
+      response("https://example.com/", 200, { "content-type": "text/html" }, "ok", {
+        allHeaders: {
+          "content-type": "text/html",
+          "set-cookie": "session=one; Path=/; HttpOnly\nclearance=two; Path=/; Secure",
+        },
+      }) as never,
+    )
+
+    expect(tracker.headers["set-cookie"]).toBeUndefined()
+    const captured = await captureResponse(tracker.response)
+    expect(captured.responseHeaders?.["set-cookie"]).toBe(
+      "session=one; Path=/; HttpOnly\nclearance=two; Path=/; Secure",
+    )
   })
 })

--- a/packages/tiers/tests/runTier1Post.test.ts
+++ b/packages/tiers/tests/runTier1Post.test.ts
@@ -141,4 +141,19 @@ describe("runTier1 — POST support", () => {
       restore()
     }
   })
+
+  test("preserves multiple Set-Cookie fields without splitting Expires commas", async () => {
+    const headers = new Headers({ "content-type": "text/html" })
+    headers.append("set-cookie", "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/")
+    headers.append("set-cookie", "clearance=two; Path=/; HttpOnly")
+    const restore = installFetchMock(() => new Response("<html>OK</html>", { headers }))
+    try {
+      const result = await runTier1("https://example.com/")
+      expect(result.responseHeaders?.["set-cookie"]).toBe(
+        "session=one; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/\nclearance=two; Path=/; HttpOnly",
+      )
+    } finally {
+      restore()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- retain the original serializer fix and contributor commit from #64
- preserve repeated cookies from Tier 1, browser responses, and direct forwarding
- emit one `Set-Cookie` field per value for buffered and streamed responses

## Testing

- `bun run verify`
- 194 tests passing

Supersedes #64.