### PR TITLE
feat(tiers): rework AWS WAF Challenge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **AWS WAF challenge detection in `detect.ts`.** `hasAwsWafChallenge()` recognises the AWS WAF JavaScript challenge page by its `awsWafCookieDomainList`, `gokuProps`, and `token.awswaf.com/challenge.js` markers. A new `"aws-waf"` variant is added to `ChallengeType` and `detectChallengeType()`, and `isChallengeWall()` now treats a 202 response with an empty body as a challenge wall — aligning it with the existing `isBlocked()` behaviour (which already notes "202 is used by some CDNs (e.g. IMDb) as a bot-gate"). Together these let the MITM proxy escalate to the browser tier for AWS WAF–protected sites.
+
 ### Fixed
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
 - Preserve every upstream `Set-Cookie` field across direct, Tier 1, and browser-backed proxy responses, serializing each cookie as its own HTTP header instead of dropping or malformedly folding repeated values (#64).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **AWS WAF challenge detection in `detect.ts`.** `hasAwsWafChallenge()` recognises the AWS WAF JavaScript challenge page by its `awsWafCookieDomainList`, `gokuProps`, and `token.awswaf.com/challenge.js` markers. A new `"aws-waf"` variant is added to `ChallengeType` and `detectChallengeType()`, and `isChallengeWall()` now treats a 202 response with an empty body as a challenge wall — aligning it with the existing `isBlocked()` behaviour (which already notes "202 is used by some CDNs (e.g. IMDb) as a bot-gate"). Together these let the MITM proxy escalate to the browser tier for AWS WAF–protected sites.
+- **AWS WAF Challenge support.** Detect the documented `202` Challenge and `405` CAPTCHA responses from their `x-amzn-waf-action` header, with a conservative two-marker HTML fallback. Silent challenges use a dedicated browser waiter for the domain-matching `aws-waf-token`; interactive CAPTCHA is surfaced as `aws-waf-captcha-required` for a future solver.
 
 ### Fixed
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).

--- a/apps/api/src/proxy/__tests__/directForward.test.ts
+++ b/apps/api/src/proxy/__tests__/directForward.test.ts
@@ -205,6 +205,40 @@ describe("directForwardHttp — buffered by default", () => {
     }
   })
 
+  test("escalates an AWS WAF Challenge header before waiting for an open body", async () => {
+    const sockets = new Set<net.Socket>()
+    const hangingServer = net.createServer((socket) => {
+      sockets.add(socket)
+      socket.once("close", () => sockets.delete(socket))
+      socket.write(
+        "HTTP/1.1 202 Accepted\r\nContent-Type: text/html\r\nX-AmZn-WaF-aCtIoN: Challenge\r\nConnection: keep-alive\r\n\r\n",
+      )
+    })
+    hangingServer.listen(0, "127.0.0.1")
+    await once(hangingServer, "listening")
+    const address = hangingServer.address()
+    if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port")
+
+    try {
+      const startedAt = performance.now()
+      const result = await directForwardHttp({
+        url: `http://127.0.0.1:${address.port}/challenge`,
+        method: "GET",
+        headers: {},
+        timeoutMs: 2_000,
+      })
+      expect(performance.now() - startedAt).toBeLessThan(500)
+      expect(result.mode).toBe("buffer")
+      if (result.mode !== "buffer") return
+      expect(result.status).toBe(202)
+      expect(result.challengeDetected).toBe(true)
+      expect(result.body.length).toBe(0)
+    } finally {
+      for (const socket of sockets) socket.destroy()
+      await new Promise<void>((resolve, reject) => hangingServer.close((error) => (error ? reject(error) : resolve())))
+    }
+  })
+
   test("buffers and de-chunks small HTML instead of treating it as a stream", async () => {
     const result = await directForwardHttp({
       url: `${baseUrl}/chunked-html`,

--- a/apps/api/src/proxy/directForward.ts
+++ b/apps/api/src/proxy/directForward.ts
@@ -240,7 +240,11 @@ async function readHttpResponse(
   // an unbounded/keep-alive response body to finish (or hit the 30s socket timeout).
   // Body-based detection below remains the fallback for challenge variants that
   // do not send this header.
-  if (!skipChallengeDetection && detectChallengeType("", headers) === "cloudflare-interstitial") {
+  const headerChallengeType = detectChallengeType("", headers, status)
+  if (
+    !skipChallengeDetection &&
+    (headerChallengeType === "cloudflare-interstitial" || headerChallengeType === "aws-waf")
+  ) {
     socket.destroy()
     return {
       mode: "buffer",
@@ -283,7 +287,7 @@ async function readHttpResponse(
       return { mode: "error", error: err instanceof Error ? err : new Error(String(err)) }
     }
     const previewText = decodeForInspection(body, headers["content-encoding"])
-    const challengeType = detectChallengeType(previewText, headers)
+    const challengeType = detectChallengeType(previewText, headers, status)
     const challengeDetected = !skipChallengeDetection && isChallengeWall(status, body.length, challengeType)
     return {
       mode: "buffer",

--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -10,6 +10,7 @@ export {
   detectChallengeType,
   hasAkamaiChallenge,
   hasDdosGuardChallenge,
+  hasAwsWafChallenge,
   hasHcaptcha,
   hasImpervaChallenge,
   hasRecaptcha,

--- a/packages/tiers/src/index.ts
+++ b/packages/tiers/src/index.ts
@@ -8,9 +8,11 @@ export { runTier4, type Tier4Result } from "./tiers/4"
 export {
   type ChallengeType,
   detectChallengeType,
+  getAwsWafAction,
   hasAkamaiChallenge,
-  hasDdosGuardChallenge,
+  hasAwsWafCaptcha,
   hasAwsWafChallenge,
+  hasDdosGuardChallenge,
   hasHcaptcha,
   hasImpervaChallenge,
   hasRecaptcha,

--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -1,7 +1,10 @@
 import { FINGERPRINT } from "@trawl/browser"
 import type { TierResult } from "@trawl/types"
 import {
+  getAwsWafAction,
   hasAkamaiChallenge,
+  hasAwsWafCaptcha,
+  hasAwsWafChallenge,
   hasHcaptcha,
   hasRecaptcha,
   hasTurnstile,
@@ -49,10 +52,9 @@ export async function runTier1(
       redirect: "follow",
     })
 
-    // Preserve raw bytes — required for binary content (.torrent, images, etc.).
-    // The MITM proxy (:8192) consumes `body`; /scrape still consumes `html`.
-    const rawBytes = new Uint8Array(await res.arrayBuffer())
-
+    // AWS WAF's action header is authoritative when paired with its documented
+    // status. Inspect it before reading the body: challenge responses may keep the
+    // body open, and waiting for arrayBuffer() would delay browser escalation.
     const responseHeaders: Record<string, string> = {}
     res.headers.forEach((v, k) => {
       responseHeaders[k] = v
@@ -60,6 +62,23 @@ export async function runTier1(
     const setCookies = res.headers.getSetCookie()
     if (setCookies.length > 0) responseHeaders["set-cookie"] = setCookies.join("\n")
     const contentType = responseHeaders["content-type"] ?? "application/octet-stream"
+    const awsAction = getAwsWafAction(res.status, responseHeaders)
+    if (awsAction) {
+      return {
+        tier: 1,
+        status: awsAction === "captcha" ? "blocked" : "needs-js",
+        durationMs: Date.now() - start,
+        reason: awsAction === "captcha" ? "aws-waf-captcha-required" : "aws-waf-challenge",
+        responseHeaders,
+        contentType,
+        body: new Uint8Array(),
+        statusCode: res.status,
+      }
+    }
+
+    // Preserve raw bytes — required for binary content (.torrent, images, etc.).
+    // The MITM proxy (:8192) consumes `body`; /scrape still consumes `html`.
+    const rawBytes = new Uint8Array(await res.arrayBuffer())
 
     // Decode a bounded preview losslessly for challenge detection — keeps the original
     // byte buffer untouched. `fatal: false` replaces invalid sequences with U+FFFD
@@ -127,6 +146,30 @@ export async function runTier1(
         status: "needs-js",
         durationMs: Date.now() - start,
         reason: "akamai-interstitial",
+        responseHeaders,
+        contentType,
+        body: rawBytes,
+        statusCode: res.status,
+      }
+    }
+    if (hasAwsWafCaptcha(previewText, responseHeaders, res.status)) {
+      return {
+        tier: 1,
+        status: "blocked",
+        durationMs: Date.now() - start,
+        reason: "aws-waf-captcha-required",
+        responseHeaders,
+        contentType,
+        body: rawBytes,
+        statusCode: res.status,
+      }
+    }
+    if (hasAwsWafChallenge(previewText, responseHeaders, res.status)) {
+      return {
+        tier: 1,
+        status: "needs-js",
+        durationMs: Date.now() - start,
+        reason: "aws-waf-challenge",
         responseHeaders,
         contentType,
         body: rawBytes,

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -57,6 +57,10 @@ export async function runTier3(
       requestReplacement: handle.requestBrowserReplacement,
     })
     const page = await freshCtx.newPage()
+    const initialAwsWafTokens = new Set<string>()
+    for (const cookie of await freshCtx.cookies()) {
+      if (cookie.name === "aws-waf-token") initialAwsWafTokens.add(`${cookie.domain}:${cookie.value}`)
+    }
     if ((extraHeaders && Object.keys(extraHeaders).length > 0) || method === "POST") {
       await page.route(url, (route: RouteLike) => {
         route.continue(routeContinueOverrides(route, extraHeaders, method, body))
@@ -83,23 +87,36 @@ export async function runTier3(
 
     const remaining = maxTimeout - (Date.now() - start)
     const peekHtml = await page.content().catch(() => "")
-    const { challengeType, resolution } = await routeChallengeWait(page, peekHtml, mainResponse.headers, remaining, url)
+    const { challengeType, resolution } = await routeChallengeWait(
+      page,
+      peekHtml,
+      mainResponse.headers,
+      remaining,
+      url,
+      undefined,
+      mainResponse.status,
+      initialAwsWafTokens,
+    )
 
     if (resolution !== "ok") {
       return {
         tier: 3,
-        status: resolution === "ip-blocked" ? "blocked" : "timeout",
+        status: resolution === "ip-blocked" || resolution === "captcha-required" ? "blocked" : "timeout",
         durationMs: Date.now() - start,
         reason:
-          resolution === "ip-blocked"
-            ? challengeType === "imperva"
-              ? "datacenter-ip-blocked (imperva sensor cookie obtained but challenge persisted — needs residential proxy)"
-              : challengeType === "akamai"
-                ? "datacenter-ip-blocked (Akamai sensor cookie obtained but challenge persisted — needs residential proxy)"
-                : challengeType === "ddos-guard"
-                  ? "datacenter-ip-blocked (DDoS-Guard clearance cookie obtained but challenge persisted — needs residential proxy)"
-                  : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
-            : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
+          resolution === "captcha-required"
+            ? "aws-waf-captcha-required"
+            : resolution === "ip-blocked"
+              ? challengeType === "imperva"
+                ? "datacenter-ip-blocked (imperva sensor cookie obtained but challenge persisted — needs residential proxy)"
+                : challengeType === "akamai"
+                  ? "datacenter-ip-blocked (Akamai sensor cookie obtained but challenge persisted — needs residential proxy)"
+                  : challengeType === "ddos-guard"
+                    ? "datacenter-ip-blocked (DDoS-Guard clearance cookie obtained but challenge persisted — needs residential proxy)"
+                    : challengeType === "aws-waf"
+                      ? "datacenter-ip-blocked (AWS WAF token obtained but challenge persisted — needs residential proxy)"
+                      : "datacenter-ip-blocked (cf_clearance obtained but redirect never completed — needs residential proxy)"
+              : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
     }
 

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -58,6 +58,10 @@ export async function runTier4(
     state.proxyContext = proxyContext
 
     const page = await proxyContext.newPage()
+    const initialAwsWafTokens = new Set<string>()
+    for (const cookie of await proxyContext.cookies()) {
+      if (cookie.name === "aws-waf-token") initialAwsWafTokens.add(`${cookie.domain}:${cookie.value}`)
+    }
 
     if ((extraHeaders && Object.keys(extraHeaders).length > 0) || method === "POST") {
       await page.route(url, (route: RouteLike) => {
@@ -80,17 +84,28 @@ export async function runTier4(
 
     const remaining = maxTimeout - (Date.now() - start)
     const peekHtml = await page.content().catch(() => "")
-    const { challengeType, resolution } = await routeChallengeWait(page, peekHtml, mainResponse.headers, remaining, url)
+    const { challengeType, resolution } = await routeChallengeWait(
+      page,
+      peekHtml,
+      mainResponse.headers,
+      remaining,
+      url,
+      undefined,
+      mainResponse.status,
+      initialAwsWafTokens,
+    )
 
     if (resolution !== "ok") {
       return {
         tier: 4,
-        status: resolution === "ip-blocked" ? "blocked" : "timeout",
+        status: resolution === "ip-blocked" || resolution === "captcha-required" ? "blocked" : "timeout",
         durationMs: Date.now() - start,
         reason:
-          resolution === "ip-blocked"
-            ? "proxy-ip-blocked"
-            : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
+          resolution === "captcha-required"
+            ? "aws-waf-captcha-required"
+            : resolution === "ip-blocked"
+              ? "proxy-ip-blocked"
+              : `${challengeType === "none" ? "cloudflare" : challengeType}-challenge-timeout`,
       }
     }
 

--- a/packages/tiers/src/utils/awsWafWait.ts
+++ b/packages/tiers/src/utils/awsWafWait.ts
@@ -1,0 +1,88 @@
+import type { Page } from "patchright"
+import { hasAwsWafCaptcha, hasAwsWafChallenge } from "./detect"
+
+export type AwsWafResolution = "ok" | "ip-blocked" | "timeout" | "captcha-required"
+
+interface WaitOptions {
+  pollMs?: number
+  stablePolls?: number
+  redirectGraceMs?: number
+  initialTokens?: ReadonlySet<string>
+}
+
+function domainMatches(host: string, cookieDomain: string): boolean {
+  const domain = cookieDomain.replace(/^\./, "").toLowerCase()
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+export async function waitForAwsWafResolution(
+  page: Page,
+  timeoutMs: number,
+  originalUrl?: string,
+  options: WaitOptions = {},
+): Promise<AwsWafResolution> {
+  if (timeoutMs <= 0) return "timeout"
+  const deadline = Date.now() + timeoutMs
+  const pollMs = options.pollMs ?? 300
+  const stablePolls = options.stablePolls ?? 2
+  const redirectGraceMs = options.redirectGraceMs ?? 3000
+  let clearPolls = 0
+  let tokenAt: number | undefined
+  let renavigated = false
+
+  let targetHost = ""
+  try {
+    targetHost = new URL(originalUrl ?? page.url()).hostname.toLowerCase()
+  } catch {}
+
+  const initialTokens =
+    options.initialTokens ??
+    new Set(
+      (
+        await page
+          .context()
+          .cookies()
+          .catch(() => [])
+      )
+        .filter((cookie) => cookie.name === "aws-waf-token" && domainMatches(targetHost, cookie.domain))
+        .map((cookie) => `${cookie.domain}:${cookie.value}`),
+    )
+
+  while (Date.now() < deadline) {
+    const html = await page.content().catch(() => "")
+    if (hasAwsWafCaptcha(html)) return "captcha-required"
+
+    const challenged = !html || hasAwsWafChallenge(html)
+    clearPolls = challenged ? 0 : clearPolls + 1
+
+    const cookies = await page
+      .context()
+      .cookies()
+      .catch(() => [])
+    const hasNewToken = cookies.some(
+      (cookie) =>
+        cookie.name === "aws-waf-token" &&
+        domainMatches(targetHost, cookie.domain) &&
+        !initialTokens.has(`${cookie.domain}:${cookie.value}`),
+    )
+
+    if (hasNewToken) {
+      tokenAt ??= Date.now()
+      if (clearPolls >= stablePolls) {
+        await page.waitForLoadState("load", { timeout: Math.max(1, deadline - Date.now()) }).catch(() => {})
+        return "ok"
+      }
+
+      if (originalUrl && !renavigated && Date.now() - tokenAt >= redirectGraceMs) {
+        renavigated = true
+        await page
+          .goto(originalUrl, { waitUntil: "domcontentloaded", timeout: Math.max(1, deadline - Date.now()) })
+          .catch(() => {})
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, Math.max(0, deadline - Date.now()))))
+  }
+
+  return tokenAt !== undefined ? "ip-blocked" : "timeout"
+}

--- a/packages/tiers/src/utils/challengeRouter.ts
+++ b/packages/tiers/src/utils/challengeRouter.ts
@@ -1,11 +1,12 @@
 import type { Page } from "patchright"
 import { waitForAkamaiResolution } from "./akamaiWait"
+import { type AwsWafResolution, waitForAwsWafResolution } from "./awsWafWait"
 import { waitForChallengeResolution } from "./challengeWait"
 import { waitForDdosGuardResolution } from "./ddosGuardWait"
-import { type ChallengeType, detectChallengeType } from "./detect"
+import { type ChallengeType, detectChallengeType, getAwsWafAction, hasAwsWafCaptcha } from "./detect"
 import { waitForImpervaResolution } from "./impervaWait"
 
-type Resolution = "ok" | "ip-blocked" | "timeout"
+type Resolution = AwsWafResolution
 type Waiter = (page: Page, timeoutMs: number, originalUrl?: string) => Promise<Resolution>
 
 interface ChallengeWaiters {
@@ -18,6 +19,12 @@ interface ChallengeWaiters {
   imperva: Waiter
   akamai: Waiter
   ddosGuard: Waiter
+  awsWaf: (
+    page: Page,
+    timeoutMs: number,
+    originalUrl?: string,
+    initialTokens?: ReadonlySet<string>,
+  ) => Promise<Resolution>
 }
 
 const defaultWaiters: ChallengeWaiters = {
@@ -25,6 +32,8 @@ const defaultWaiters: ChallengeWaiters = {
   imperva: waitForImpervaResolution,
   akamai: waitForAkamaiResolution,
   ddosGuard: waitForDdosGuardResolution,
+  awsWaf: (page, timeoutMs, originalUrl, initialTokens) =>
+    waitForAwsWafResolution(page, timeoutMs, originalUrl, { initialTokens }),
 }
 
 export async function routeChallengeWait(
@@ -34,8 +43,13 @@ export async function routeChallengeWait(
   timeoutMs: number,
   originalUrl?: string,
   waiters: ChallengeWaiters = defaultWaiters,
+  status?: number,
+  initialAwsWafTokens?: ReadonlySet<string>,
 ): Promise<{ challengeType: ChallengeType; resolution: Resolution }> {
-  const challengeType = detectChallengeType(html, headers)
+  const challengeType = detectChallengeType(html, headers, status)
+  if (getAwsWafAction(status, headers) === "captcha" || hasAwsWafCaptcha(html)) {
+    return { challengeType: "aws-waf", resolution: "captcha-required" }
+  }
   const resolution =
     challengeType === "imperva"
       ? await waiters.imperva(page, timeoutMs, originalUrl)
@@ -43,6 +57,8 @@ export async function routeChallengeWait(
         ? await waiters.akamai(page, timeoutMs, originalUrl)
         : challengeType === "ddos-guard"
           ? await waiters.ddosGuard(page, timeoutMs, originalUrl)
-          : await waiters.cloudflare(page, timeoutMs, originalUrl, () => headers)
+          : challengeType === "aws-waf"
+            ? await waiters.awsWaf(page, timeoutMs, originalUrl, initialAwsWafTokens)
+            : await waiters.cloudflare(page, timeoutMs, originalUrl, () => headers)
   return { challengeType, resolution }
 }

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -7,6 +7,7 @@ export type ChallengeType =
   | "imperva"
   | "akamai"
   | "ddos-guard"
+  | "aws-waf"
   | "none"
 
 export function hasCloudflareChallengeHeader(headers: Record<string, string> = {}): boolean {
@@ -121,6 +122,12 @@ export function hasDdosGuardChallenge(html: string, _headers: Record<string, str
   return false
 }
 
+// AWS WAF JavaScript challenge — the interstitial page that loads challenge.js to
+// issue an aws-waf-token cookie before redirecting to the protected resource.
+export function hasAwsWafChallenge(html: string): boolean {
+  return /awsWafCookieDomainList|window\.gokuProps|token\.awswaf\.com\/[^"']*challenge\.js/i.test(html)
+}
+
 export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
   if (hasCloudflareChallengeHeader(headers)) return "cloudflare-interstitial"
   if (hasTurnstile(html)) return "cloudflare-turnstile"
@@ -131,6 +138,7 @@ export function detectChallengeType(html: string, headers: Record<string, string
   if (hasHcaptcha(html)) return "hcaptcha"
   if (hasRecaptcha(html)) return "recaptcha"
   if (hasCapChallenge(html)) return "cap"
+  if (hasAwsWafChallenge(html)) return "aws-waf"
   return "none"
 }
 
@@ -168,9 +176,12 @@ const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
 // checks are TRAWL-specific heuristics (CF's auto-resolving bootstrap and Imperva's
 // sensor cookie challenge can come at 200 with body < a few KB).
 export function isChallengeWall(status: number, bodyLength: number, challengeType: ChallengeType): boolean {
+  // AWS WAF returns 202 with an empty body as the JS-challenge gate; isBlocked() already
+  // handles 202, but isChallengeWall() is used independently in the MITM proxy path.
+  if (status === 202 && bodyLength === 0) return true
   if (challengeType === "none") return false
   if (status === 403 || status === 503) return true
-  if (challengeType === "akamai") return true
+  if (challengeType === "akamai" || challengeType === "aws-waf") return true
   const threshold = LEAN_BODY_THRESHOLDS[challengeType]
   if (threshold !== undefined && bodyLength < threshold) return true
   return false

--- a/packages/tiers/src/utils/detect.ts
+++ b/packages/tiers/src/utils/detect.ts
@@ -15,6 +15,22 @@ export function hasCloudflareChallengeHeader(headers: Record<string, string> = {
   return cfMitigated?.toLowerCase() === "challenge"
 }
 
+function headerValue(headers: Record<string, string>, name: string): string | undefined {
+  return Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1]
+}
+
+export type AwsWafAction = "challenge" | "captcha"
+
+export function getAwsWafAction(
+  status: number | undefined,
+  headers: Record<string, string> = {},
+): AwsWafAction | undefined {
+  const action = headerValue(headers, "x-amzn-waf-action")?.trim().toLowerCase()
+  if (status === 202 && action === "challenge") return "challenge"
+  if (status === 405 && action === "captcha") return "captcha"
+  return undefined
+}
+
 export function isCloudflarePage(html: string, headers: Record<string, string>): boolean {
   if (hasCloudflareChallengeHeader(headers)) return true
   if (hasDdosGuardChallenge(html)) return false
@@ -124,11 +140,22 @@ export function hasDdosGuardChallenge(html: string, _headers: Record<string, str
 
 // AWS WAF JavaScript challenge — the interstitial page that loads challenge.js to
 // issue an aws-waf-token cookie before redirecting to the protected resource.
-export function hasAwsWafChallenge(html: string): boolean {
-  return /awsWafCookieDomainList|window\.gokuProps|token\.awswaf\.com\/[^"']*challenge\.js/i.test(html)
+export function hasAwsWafChallenge(html: string, headers: Record<string, string> = {}, status?: number): boolean {
+  if (getAwsWafAction(status, headers) === "challenge") return true
+  return /window\.gokuProps/i.test(html) && /token\.awswaf\.com\/[^"']*challenge\.js/i.test(html)
 }
 
-export function detectChallengeType(html: string, headers: Record<string, string> = {}): ChallengeType {
+export function hasAwsWafCaptcha(html: string, headers: Record<string, string> = {}, status?: number): boolean {
+  if (getAwsWafAction(status, headers) === "captcha") return true
+  return /window\.gokuProps/i.test(html) && /token\.awswaf\.com\/[^"']*captcha\.js/i.test(html)
+}
+
+export function detectChallengeType(
+  html: string,
+  headers: Record<string, string> = {},
+  status?: number,
+): ChallengeType {
+  if (hasAwsWafChallenge(html, headers, status) || hasAwsWafCaptcha(html, headers, status)) return "aws-waf"
   if (hasCloudflareChallengeHeader(headers)) return "cloudflare-interstitial"
   if (hasTurnstile(html)) return "cloudflare-turnstile"
   if (hasDdosGuardChallenge(html, headers)) return "ddos-guard"
@@ -138,13 +165,11 @@ export function detectChallengeType(html: string, headers: Record<string, string
   if (hasHcaptcha(html)) return "hcaptcha"
   if (hasRecaptcha(html)) return "recaptcha"
   if (hasCapChallenge(html)) return "cap"
-  if (hasAwsWafChallenge(html)) return "aws-waf"
   return "none"
 }
 
 export function isBlocked(status: number, html: string): boolean {
-  // 202 is used by some CDNs (e.g. IMDB) as a bot-gate before the real response
-  if (status === 202 || status === 403 || status === 429) return true
+  if (status === 403 || status === 429) return true
   if (isCloudflarePage(html, {})) return true
   if (hasImpervaChallenge(html)) return true
   if (hasAkamaiChallenge(html)) return true
@@ -176,9 +201,6 @@ const LEAN_BODY_THRESHOLDS: Partial<Record<ChallengeType, number>> = {
 // checks are TRAWL-specific heuristics (CF's auto-resolving bootstrap and Imperva's
 // sensor cookie challenge can come at 200 with body < a few KB).
 export function isChallengeWall(status: number, bodyLength: number, challengeType: ChallengeType): boolean {
-  // AWS WAF returns 202 with an empty body as the JS-challenge gate; isBlocked() already
-  // handles 202, but isChallengeWall() is used independently in the MITM proxy path.
-  if (status === 202 && bodyLength === 0) return true
   if (challengeType === "none") return false
   if (status === 403 || status === 503) return true
   if (challengeType === "akamai" || challengeType === "aws-waf") return true

--- a/packages/tiers/tests/awsWaf.test.ts
+++ b/packages/tiers/tests/awsWaf.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { detectChallengeType, hasAwsWafChallenge, isChallengeWall } from "../src/utils/detect"
+
+// Minimal AWS WAF JS-challenge page — the real page loads challenge.js from
+// token.awswaf.com and sets an aws-waf-token cookie before redirecting.
+const awsWafInterstitial = `
+  <!DOCTYPE html>
+  <html>
+    <head><title>Request unsuccessful</title></head>
+    <body>
+      <script>
+        window.awsWafCookieDomainList = ['example.com'];
+        window.gokuProps = {"key":"AQIDAHjcYu0fake","iv":"abc123==","context":"def456=="};
+      </script>
+      <script src="https://abc123.token.awswaf.com/abc123/challenge.js" defer></script>
+    </body>
+  </html>
+`
+
+describe("AWS WAF challenge detection", () => {
+  test("detects the JS-challenge interstitial by awsWafCookieDomainList", () => {
+    expect(hasAwsWafChallenge(awsWafInterstitial)).toBe(true)
+    expect(detectChallengeType(awsWafInterstitial)).toBe("aws-waf")
+  })
+
+  test("detects the interstitial by gokuProps alone", () => {
+    const html = `<html><body><script>window.gokuProps = {"key":"AQI"}</script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(true)
+  })
+
+  test("detects the interstitial by challenge.js script src", () => {
+    const html = `<html><body><script src="https://x.token.awswaf.com/x/challenge.js"></script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(true)
+  })
+
+  test("does not flag a full page that merely loads AWS resources", () => {
+    const html = `<html><body>${"real content ".repeat(400)}<script src="https://sdk.amazonaws.com/js/aws-sdk-2.0.0.min.js"></script></body></html>`
+    expect(hasAwsWafChallenge(html)).toBe(false)
+    expect(detectChallengeType(html)).toBe("none")
+  })
+
+  test("treats an AWS WAF interstitial as a proxy challenge wall", () => {
+    expect(isChallengeWall(200, Buffer.byteLength(awsWafInterstitial), "aws-waf")).toBe(true)
+  })
+
+  test("treats a 202 response with empty body as a challenge wall regardless of type", () => {
+    // AWS WAF returns HTTP 202 with a 0-byte body as a bot-gate before the JS
+    // challenge page. isBlocked() already handles this for /scrape; isChallengeWall()
+    // now matches so the MITM proxy path escalates consistently.
+    expect(isChallengeWall(202, 0, "none")).toBe(true)
+  })
+
+  test("does not flag a non-empty 202 as a challenge wall", () => {
+    // A legitimate 202 Accepted with a response body must not be escalated.
+    expect(isChallengeWall(202, 512, "none")).toBe(false)
+  })
+})

--- a/packages/tiers/tests/awsWaf.test.ts
+++ b/packages/tiers/tests/awsWaf.test.ts
@@ -1,57 +1,48 @@
 import { describe, expect, test } from "bun:test"
-import { detectChallengeType, hasAwsWafChallenge, isChallengeWall } from "../src/utils/detect"
+import {
+  detectChallengeType,
+  getAwsWafAction,
+  hasAwsWafCaptcha,
+  hasAwsWafChallenge,
+  isChallengeWall,
+} from "../src/utils/detect"
 
-// Minimal AWS WAF JS-challenge page — the real page loads challenge.js from
-// token.awswaf.com and sets an aws-waf-token cookie before redirecting.
-const awsWafInterstitial = `
-  <!DOCTYPE html>
-  <html>
-    <head><title>Request unsuccessful</title></head>
-    <body>
-      <script>
-        window.awsWafCookieDomainList = ['example.com'];
-        window.gokuProps = {"key":"AQIDAHjcYu0fake","iv":"abc123==","context":"def456=="};
-      </script>
-      <script src="https://abc123.token.awswaf.com/abc123/challenge.js" defer></script>
-    </body>
-  </html>
-`
+const challengeHtml = `<script>window.gokuProps={"key":"x"}</script><script src="https://x.token.awswaf.com/x/challenge.js"></script>`
+const captchaHtml = `<script>window.gokuProps={"key":"x"}</script><script src="https://x.token.awswaf.com/x/captcha.js"></script>`
 
 describe("AWS WAF challenge detection", () => {
-  test("detects the JS-challenge interstitial by awsWafCookieDomainList", () => {
-    expect(hasAwsWafChallenge(awsWafInterstitial)).toBe(true)
-    expect(detectChallengeType(awsWafInterstitial)).toBe("aws-waf")
+  test("recognizes case-insensitive authoritative Challenge and CAPTCHA headers with their statuses", () => {
+    expect(getAwsWafAction(202, { "X-AmZn-WaF-aCtIoN": "Challenge" })).toBe("challenge")
+    expect(getAwsWafAction(405, { "X-AMZN-WAF-ACTION": "CAPTCHA" })).toBe("captcha")
+    expect(detectChallengeType("", { "X-Amzn-Waf-Action": "challenge" }, 202)).toBe("aws-waf")
+    expect(detectChallengeType("", { "x-amzn-waf-action": "captcha" }, 405)).toBe("aws-waf")
   })
 
-  test("detects the interstitial by gokuProps alone", () => {
-    const html = `<html><body><script>window.gokuProps = {"key":"AQI"}</script></body></html>`
-    expect(hasAwsWafChallenge(html)).toBe(true)
+  test("requires the matching status for an action header", () => {
+    expect(getAwsWafAction(200, { "x-amzn-waf-action": "challenge" })).toBeUndefined()
+    expect(getAwsWafAction(202, { "x-amzn-waf-action": "captcha" })).toBeUndefined()
   })
 
-  test("detects the interstitial by challenge.js script src", () => {
-    const html = `<html><body><script src="https://x.token.awswaf.com/x/challenge.js"></script></body></html>`
-    expect(hasAwsWafChallenge(html)).toBe(true)
+  test("uses gokuProps plus the matching script for HTML fallback", () => {
+    expect(hasAwsWafChallenge(challengeHtml)).toBe(true)
+    expect(hasAwsWafCaptcha(captchaHtml)).toBe(true)
+    expect(detectChallengeType(challengeHtml)).toBe("aws-waf")
   })
 
-  test("does not flag a full page that merely loads AWS resources", () => {
-    const html = `<html><body>${"real content ".repeat(400)}<script src="https://sdk.amazonaws.com/js/aws-sdk-2.0.0.min.js"></script></body></html>`
-    expect(hasAwsWafChallenge(html)).toBe(false)
-    expect(detectChallengeType(html)).toBe("none")
+  test("does not classify individual integration markers", () => {
+    expect(hasAwsWafChallenge(`<script src="https://x.token.awswaf.com/x/challenge.js"></script>`)).toBe(false)
+    expect(hasAwsWafChallenge(`<script>window.awsWafCookieDomainList=['example.com']</script>`)).toBe(false)
+    expect(hasAwsWafChallenge(`<script>window.gokuProps={}</script>`)).toBe(false)
   })
 
-  test("treats an AWS WAF interstitial as a proxy challenge wall", () => {
-    expect(isChallengeWall(200, Buffer.byteLength(awsWafInterstitial), "aws-waf")).toBe(true)
-  })
-
-  test("treats a 202 response with empty body as a challenge wall regardless of type", () => {
-    // AWS WAF returns HTTP 202 with a 0-byte body as a bot-gate before the JS
-    // challenge page. isBlocked() already handles this for /scrape; isChallengeWall()
-    // now matches so the MITM proxy path escalates consistently.
-    expect(isChallengeWall(202, 0, "none")).toBe(true)
-  })
-
-  test("does not flag a non-empty 202 as a challenge wall", () => {
-    // A legitimate 202 Accepted with a response body must not be escalated.
+  test("leaves empty and non-empty ordinary 202 responses alone", () => {
+    expect(detectChallengeType("", {}, 202)).toBe("none")
+    expect(isChallengeWall(202, 0, "none")).toBe(false)
     expect(isChallengeWall(202, 512, "none")).toBe(false)
+  })
+
+  test("treats a positively identified AWS response as a wall", () => {
+    expect(isChallengeWall(202, 0, "aws-waf")).toBe(true)
+    expect(isChallengeWall(405, 0, "aws-waf")).toBe(true)
   })
 })

--- a/packages/tiers/tests/awsWafWait.test.ts
+++ b/packages/tiers/tests/awsWafWait.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import type { Page } from "patchright"
+import { waitForAwsWafResolution } from "../src/utils/awsWafWait"
+
+const wall = `<script>window.gokuProps={}</script><script src="https://x.token.awswaf.com/x/challenge.js"></script>`
+const captcha = `<script>window.gokuProps={}</script><script src="https://x.token.awswaf.com/x/captcha.js"></script>`
+
+function pageFixture(options: {
+  html: () => string
+  cookies: () => Array<{ name: string; domain: string; value: string }>
+}) {
+  let gotos = 0
+  const page = {
+    url: () => "https://shop.example.test/item",
+    content: async () => options.html(),
+    context: () => ({ cookies: async () => options.cookies() }),
+    waitForLoadState: async () => {},
+    goto: async () => {
+      gotos++
+      return null
+    },
+  } as unknown as Page
+  return { page, gotos: () => gotos }
+}
+
+describe("AWS WAF waiter", () => {
+  test("waits for a new domain-matching token and stable wall disappearance", async () => {
+    let reads = 0
+    const fixture = pageFixture({
+      html: () => (++reads < 3 ? wall : "<html>real content</html>"),
+      cookies: () => (reads >= 2 ? [{ name: "aws-waf-token", domain: ".example.test", value: "new-token" }] : []),
+    })
+    expect(
+      await waitForAwsWafResolution(fixture.page, 100, "https://shop.example.test/item", {
+        pollMs: 1,
+        stablePolls: 2,
+      }),
+    ).toBe("ok")
+  })
+
+  test("renavigates the original URL when a token exists but the wall persists", async () => {
+    let cleared = false
+    let cookieReads = 0
+    const fixture = pageFixture({
+      html: () => (cleared ? "<html>real content</html>" : wall),
+      cookies: () =>
+        ++cookieReads > 1 ? [{ name: "aws-waf-token", domain: "shop.example.test", value: "new-token" }] : [],
+    })
+    const originalGoto = fixture.page.goto.bind(fixture.page)
+    fixture.page.goto = (async (...args: Parameters<Page["goto"]>) => {
+      cleared = true
+      return originalGoto(...args)
+    }) as Page["goto"]
+    expect(
+      await waitForAwsWafResolution(fixture.page, 100, "https://shop.example.test/item", {
+        pollMs: 1,
+        stablePolls: 1,
+        redirectGraceMs: 0,
+      }),
+    ).toBe("ok")
+    expect(fixture.gotos()).toBe(1)
+  })
+
+  test("reports a persistent challenge after token acquisition as blocked", async () => {
+    let cookieReads = 0
+    const fixture = pageFixture({
+      html: () => wall,
+      cookies: () => (++cookieReads > 1 ? [{ name: "aws-waf-token", domain: "example.test", value: "new-token" }] : []),
+    })
+    expect(
+      await waitForAwsWafResolution(fixture.page, 15, "https://example.test/", {
+        pollMs: 1,
+        redirectGraceMs: 0,
+      }),
+    ).toBe("ip-blocked")
+  })
+
+  test("surfaces interactive CAPTCHA without attempting an audio solver", async () => {
+    const fixture = pageFixture({ html: () => captcha, cookies: () => [] })
+    expect(await waitForAwsWafResolution(fixture.page, 50, "https://example.test/", { pollMs: 1 })).toBe(
+      "captcha-required",
+    )
+  })
+})

--- a/packages/tiers/tests/challengeRouter.test.ts
+++ b/packages/tiers/tests/challengeRouter.test.ts
@@ -21,6 +21,7 @@ describe("browser challenge routing", () => {
         ddosGuard: waiter("ddos-guard"),
         imperva: waiter("imperva"),
         akamai: waiter("akamai"),
+        awsWaf: waiter("aws-waf"),
       },
     )
 
@@ -39,9 +40,52 @@ describe("browser challenge routing", () => {
       ddosGuard: waiter("ddos-guard"),
       imperva: waiter("imperva"),
       akamai: waiter("akamai"),
+      awsWaf: waiter("aws-waf"),
     })
 
     expect(result.challengeType).toBe("ddos-guard")
     expect(calls).toEqual(["ddos-guard"])
+  })
+
+  test("routes AWS WAF to its dedicated waiter", async () => {
+    const calls: string[] = []
+    const waiter = (name: string) => async () => {
+      calls.push(name)
+      return "ok" as const
+    }
+    const result = await routeChallengeWait(
+      {} as Page,
+      "",
+      { "X-Amzn-Waf-Action": "Challenge" },
+      100,
+      "https://example.test/",
+      {
+        cloudflare: waiter("cloudflare"),
+        ddosGuard: waiter("ddos-guard"),
+        imperva: waiter("imperva"),
+        akamai: waiter("akamai"),
+        awsWaf: waiter("aws-waf"),
+      },
+      202,
+    )
+
+    expect(result).toEqual({ challengeType: "aws-waf", resolution: "ok" })
+    expect(calls).toEqual(["aws-waf"])
+  })
+
+  test("returns CAPTCHA-required without invoking a waiter", async () => {
+    const fail = async () => {
+      throw new Error("waiter must not run")
+    }
+    const result = await routeChallengeWait(
+      {} as Page,
+      "",
+      { "x-amzn-waf-action": "captcha" },
+      100,
+      undefined,
+      { cloudflare: fail, ddosGuard: fail, imperva: fail, akamai: fail, awsWaf: fail },
+      405,
+    )
+    expect(result).toEqual({ challengeType: "aws-waf", resolution: "captcha-required" })
   })
 })

--- a/packages/tiers/tests/runTier1AwsWaf.test.ts
+++ b/packages/tiers/tests/runTier1AwsWaf.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import { runTier1 } from "../src/tiers/1"
+
+async function withFetch(response: Response, run: () => Promise<void>) {
+  const original = globalThis.fetch
+  ;(globalThis as { fetch: typeof fetch }).fetch = (async () => response) as typeof fetch
+  try {
+    await run()
+  } finally {
+    ;(globalThis as { fetch: typeof fetch }).fetch = original
+  }
+}
+
+describe("Tier 1 AWS WAF handling", () => {
+  test("escalates Challenge from headers before consuming an open body and preserves metadata", async () => {
+    const openBody = new ReadableStream<Uint8Array>({ start() {} })
+    await withFetch(
+      new Response(openBody, {
+        status: 202,
+        headers: { "X-Amzn-Waf-Action": "Challenge", "Content-Type": "text/html", "X-Test": "kept" },
+      }),
+      async () => {
+        const result = await Promise.race([
+          runTier1("https://example.test/"),
+          new Promise<never>((_, reject) => setTimeout(() => reject(new Error("body was consumed")), 100)),
+        ])
+        expect(result.status).toBe("needs-js")
+        expect(result.reason).toBe("aws-waf-challenge")
+        expect(result.statusCode).toBe(202)
+        expect(result.responseHeaders?.["x-test"]).toBe("kept")
+      },
+    )
+  })
+
+  test("returns interactive CAPTCHA as explicitly blocked", async () => {
+    await withFetch(new Response("", { status: 405, headers: { "x-amzn-waf-action": "captcha" } }), async () => {
+      const result = await runTier1("https://example.test/")
+      expect(result.status).toBe("blocked")
+      expect(result.reason).toBe("aws-waf-captcha-required")
+      expect(result.statusCode).toBe(405)
+    })
+  })
+
+  test("allows legitimate empty and non-empty 202 responses", async () => {
+    for (const body of ["", "accepted"]) {
+      await withFetch(new Response(body, { status: 202, headers: { "content-type": "text/plain" } }), async () => {
+        const result = await runTier1("https://example.test/")
+        expect(result.status).toBe("success")
+        expect(result.html).toBe(body)
+      })
+    }
+  })
+
+  test("escalates only the combined HTML fallback markers", async () => {
+    const challenge = `<script>window.gokuProps={}</script><script src="https://x.token.awswaf.com/x/challenge.js"></script>`
+    await withFetch(new Response(challenge, { status: 200, headers: { "content-type": "text/html" } }), async () => {
+      expect((await runTier1("https://example.test/")).reason).toBe("aws-waf-challenge")
+    })
+    await withFetch(
+      new Response(`<script src="https://x.token.awswaf.com/x/challenge.js"></script>`, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+      async () => {
+        expect((await runTier1("https://example.test/")).status).toBe("success")
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- preserve the original AWS WAF contribution and harden detection around the documented status/header pairs
- escalate silent Challenge responses in Tier 0 and Tier 1 without consuming a potentially open body
- route browser tiers through a dedicated AWS waiter that verifies a new domain-matching token and stable interstitial clearance
- surface interactive CAPTCHA as `aws-waf-captcha-required` without importing the experimental audio solver

## Detection rules

- `202` + `x-amzn-waf-action: challenge`
- `405` + `x-amzn-waf-action: captcha`
- HTML fallback only when `window.gokuProps` and the matching AWS WAF script occur together

Legitimate empty/non-empty `202` responses and individual integration markers remain untouched.

## Verification

- `bun run verify`
- 211 tests pass
- typecheck and production builds pass

Supersedes #65 and replaces the broad experiment in #62 with narrowly scoped, verified silent Challenge support.