### PR TITLE
ci: resolve the ghcr image name in lowercase

### DIFF
--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -45,10 +45,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v7
@@ -102,10 +100,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@v8

--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -45,6 +45,12 @@ jobs:
       contents: read
       packages: write
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - uses: docker/login-action@v4
@@ -96,6 +102,12 @@ jobs:
       contents: read
       packages: write
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -38,6 +38,12 @@ jobs:
       packages: write
 
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - uses: docker/login-action@v4
@@ -93,6 +99,12 @@ jobs:
       packages: write
 
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -38,10 +38,8 @@ jobs:
       packages: write
 
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v7
@@ -99,10 +97,8 @@ jobs:
       packages: write
 
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@v8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,12 @@ jobs:
       packages: write
 
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - uses: docker/login-action@v4
@@ -98,6 +104,12 @@ jobs:
       packages: write
 
     steps:
+      # GHCR refuses a reference with uppercase characters, and github.repository_owner
+      # keeps the account's original casing. Expressions have no lowercase function, so
+      # the image name is resolved here instead of in the workflow-level env.
+      - name: Resolve lowercase image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
+
       - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,8 @@ jobs:
       packages: write
 
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v7
@@ -104,10 +102,8 @@ jobs:
       packages: write
 
     steps:
-      # GHCR refuses a reference with uppercase characters, and github.repository_owner
-      # keeps the account's original casing. Expressions have no lowercase function, so
-      # the image name is resolved here instead of in the workflow-level env.
-      - name: Resolve lowercase image name
+      - name: Normalize GHCR image name
+        shell: bash
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/trawl" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

The publish workflows build `IMAGE: ghcr.io/${{ github.repository_owner }}/trawl`. GHCR rejects a reference with uppercase characters, and `github.repository_owner` keeps the account's original casing, so every fork whose owner has capitals fails the build:

```
ERROR: failed to solve: failed to parse ref "ghcr.io/CappyT/trawl":
invalid reference format: repository name (CappyT/trawl) must be lowercase
```

Actions expressions have no lowercase function, so the image name is resolved in a bash step instead of in the workflow-level `env`, one per job that uses it (`build` and `merge` in publish, publish-baseline and publish-nightly).

No effect on this repo: `germondai` is already lowercase and resolves to the same value.

Verified on a fork: `v1.5.0` failed before the change and published `:1.5.0`, `:latest`, `:1.5.0-baseline` and `:baseline` as multi-arch manifests after it.

## Linked issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [ ] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [ ] I added or updated tests for the behavior change (if applicable)
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE).
