### PR TITLE
73 flaresolverr returns successtrue for broken proxy error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
 - Preserve every upstream `Set-Cookie` field across direct, Tier 1, and browser-backed proxy responses, serializing each cookie as its own HTTP header instead of dropping or malformedly folding repeated values (#64).
+- Treat an explicit request-level `proxy` as a strict routing guarantee: route HTTP(S) Tier 1 requests through it, skip direct Tier 1 for SOCKS, bypass the unproxied Tier 2 cache, prevent proxy-derived sessions from entering the shared domain cache, disable Firefox direct failover, and surface authentication, transport, protocol, and `Proxy-Status` failures as errors instead of successful content (#73).
 
 ## [1.4.2] - 2026-08-22
 

--- a/apps/api/src/routes/v1.test.ts
+++ b/apps/api/src/routes/v1.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { type OrchestratorDeps, ScrapeError } from "@trawl/tiers"
+import { v1Route } from "./v1"
+
+describe("POST /v1", () => {
+  test("returns a FlareSolverr error envelope when an explicit proxy fails", async () => {
+    const app = v1Route({
+      poolReady: () => true,
+      orchestratorDeps: () => ({}) as OrchestratorDeps,
+      runScrape: async () => {
+        throw new ScrapeError("All tiers exhausted. Last failure: proxy-connection-failed", [
+          { tier: 1, status: "error", durationMs: 1, reason: "proxy-connection-failed" },
+        ])
+      },
+    })
+
+    const response = await app.handle(
+      new Request("http://localhost/v1", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          cmd: "request.get",
+          url: "https://target.example",
+          proxy: "http://proxy.example:8080",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({
+      status: "error",
+      message: "All tiers exhausted. Last failure: proxy-connection-failed",
+      solution: { url: "https://target.example", status: 0, response: "" },
+    })
+  })
+})

--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -7,7 +7,17 @@ import { getDeps, getPool } from "../deps"
 import { requestUrl, validateFlareSolverrRequest } from "../validation"
 
 // FlareSolverr v2 compat — always open (the v2 spec has no auth header)
-export function v1Route() {
+interface V1RouteOptions {
+  runScrape?: typeof scrape
+  poolReady?: () => boolean
+  orchestratorDeps?: typeof getDeps
+}
+
+export function v1Route({
+  runScrape = scrape,
+  poolReady = () => Boolean(getPool()),
+  orchestratorDeps = getDeps,
+}: V1RouteOptions = {}) {
   return new Elysia().post("/v1", async ({ body, set }) => {
     const startTimestamp = Date.now()
 
@@ -21,13 +31,13 @@ export function v1Route() {
         return flareSolverrError(req.url, `Unknown cmd: ${cmd}`)
       }
 
-      if (!getPool()) {
+      if (!poolReady()) {
         set.status = 503
         return flareSolverrError(req.url, "Browser pool initializing, retry in a few seconds")
       }
 
       const scrapeRequest = buildScrapeRequestFromFlareSolverr(req)
-      const result = await scrape(scrapeRequest, getDeps())
+      const result = await runScrape(scrapeRequest, orchestratorDeps())
       return {
         status: "ok",
         message: "",

--- a/apps/docs/api-reference/native-api.md
+++ b/apps/docs/api-reference/native-api.md
@@ -31,7 +31,7 @@ interface ScrapeRequest {
 | `maxTier`    | 1–4     | 4        | Never escalate beyond this tier                                                                                                                                                                |
 | `sessionId`  | string  | hostname | Override the Redis session key                                                                                                                                                                 |
 | `headers`    | object  | —        | Custom headers forwarded to the target across all tiers — see [Custom Headers](/api-reference/custom-headers)                                                                                  |
-| `proxy`      | string  | —        | Proxy URL used for this request's Tier 3/4 attempts instead of the configured `PROXY_URL`/`RESIDENTIAL_PROXY_URL` pool — see [Configuration § Proxies](/getting-started/configuration#proxies) |
+| `proxy`      | string  | —        | Strict proxy route for this request. HTTP(S) proxies are used by Tier 1 and browser tiers; SOCKS proxies skip Tier 1. Direct Tier 1 and the unproxied Tier 2 cache are never used — see [Configuration § Proxies](/getting-started/configuration#proxies) |
 
 ## Response
 

--- a/apps/docs/getting-started/configuration.md
+++ b/apps/docs/getting-started/configuration.md
@@ -115,6 +115,8 @@ SESSION_TTL_SECONDS=1800   # more conservative
 
 ### `PROXY_URL`
 
+These environment-level proxies are escalation pools: direct Tier 1 and cached Tier 2 may complete before they are used. In contrast, the API request-level `proxy` field is a routing guarantee; target traffic for that request never falls back to a direct connection.
+
 **Default:** _(empty — no proxy)_
 
 Datacenter proxy pool used for Tier 3 (fresh challenge solve). TRAWL passes these endpoints to the

--- a/packages/browser/src/pool.ts
+++ b/packages/browser/src/pool.ts
@@ -21,6 +21,11 @@ const CLOSE_TIMEOUT_MS = 10_000
 // launch timeout does not cover. 90s is generous but finite.
 const LAUNCH_TIMEOUT_MS = 90_000
 
+/** Firefox must never silently retry a proxied navigation over the host's direct route. */
+export const PROXY_SAFETY_FIREFOX_PREFS = Object.freeze({
+  "network.proxy.failover_direct": false,
+})
+
 type AsyncAction = () => unknown | Promise<unknown>
 
 const settle = (action: AsyncAction): Promise<void> =>
@@ -244,6 +249,8 @@ export class BrowserPool {
       // maps this to firefoxUserPrefs). The earlier `prefs` key was silently
       // ignored, so these settings were dead code in 1.0.0.
       firefox_user_prefs: {
+        // Never bypass a configured proxy when it is unavailable.
+        ...PROXY_SAFETY_FIREFOX_PREFS,
         "dom.ipc.processCount": this.contentProcesses,
         "dom.ipc.processPrelaunch": false,
         "dom.ipc.contentProcessCount": this.contentProcesses,

--- a/packages/browser/tests/pool.test.ts
+++ b/packages/browser/tests/pool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { BrowserPool } from "../src/pool"
+import { BrowserPool, PROXY_SAFETY_FIREFOX_PREFS } from "../src/pool"
 
 const pools: BrowserPool[] = []
 
@@ -63,6 +63,10 @@ function makeFactory() {
 }
 
 describe("BrowserPool recycling", () => {
+  test("disables Firefox direct fallback for proxied navigations", () => {
+    expect(PROXY_SAFETY_FIREFOX_PREFS["network.proxy.failover_direct"]).toBeFalse()
+  })
+
   test("publishes the first browser before warming remaining capacity concurrently", async () => {
     const { factory: baseFactory } = makeFactory()
     let activeLaunches = 0

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -38,6 +38,12 @@ export interface OrchestratorDeps {
   onTierAttempt?: (result: TierResult) => void
 }
 
+interface OrchestratorRunners {
+  tier2?: typeof runTier2
+  tier3?: typeof runTier3
+  tier4?: typeof runTier4
+}
+
 const extractDomain = (url: string): string => {
   try {
     return new URL(url).hostname
@@ -49,12 +55,19 @@ const extractDomain = (url: string): string => {
 const hasUsablePayload = (result: { status: TierResult["status"]; html?: string; body?: Uint8Array }): boolean =>
   result.status === "success" && (result.body !== undefined || Boolean(result.html))
 
-export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promise<ScrapeResult> {
+export async function scrape(
+  req: ScrapeRequest,
+  deps: OrchestratorDeps,
+  runners: OrchestratorRunners = {},
+): Promise<ScrapeResult> {
   const totalStart = Date.now()
   const maxTimeout = req.maxTimeout ?? 60_000
   const maxTier = req.maxTier ?? 4
   const timings: TierResult[] = []
   const domain = extractDomain(req.url)
+  const explicitProxy = req.proxy
+  const tier1Proxy = explicitProxy && /^https?:\/\//i.test(explicitProxy) ? explicitProxy : undefined
+  const skipTier1ForProxy = Boolean(explicitProxy && !tier1Proxy)
 
   const sanitizedHeaders = sanitizeHeaders(req.headers)
   requireContentTypeForBody(sanitizedHeaders, Boolean(req.body))
@@ -65,9 +78,12 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
   }
 
   // Tier 1: plain HTTP fetch
-  if (!req.skipHttp && maxTier >= 1) {
-    const t1 = await runTier1(req.url, sanitizedHeaders, req.method, req.body)
+  if (!req.skipHttp && !skipTier1ForProxy && maxTier >= 1) {
+    const t1 = await runTier1(req.url, sanitizedHeaders, req.method, req.body, tier1Proxy)
     emit(t1)
+    if (explicitProxy && t1.status === "error" && t1.reason?.startsWith("proxy-")) {
+      throw new ScrapeError(t1.reason, timings)
+    }
     if (hasUsablePayload(t1)) {
       // Tier 1 doesn't acquire a browser (it's a plain HTTP fetch). Use a random fingerprint
       // UA from the pool so even Tier 1 requests don't share a single signature.
@@ -82,7 +98,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
         sessionCached: false,
         timings,
         totalMs: Date.now() - totalStart,
-        proxyUsed: false,
+        proxyUsed: Boolean(tier1Proxy),
         body: t1.body,
         responseHeaders: t1.responseHeaders,
         contentType: t1.contentType,
@@ -101,10 +117,18 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
 
   try {
     // Tier 2: browser with cached session
-    const session = await deps.loadSession(domain)
+    const session = explicitProxy ? undefined : await deps.loadSession(domain)
     if (session && maxTier >= 2) {
       const remaining = maxTimeout - (Date.now() - totalStart)
-      const t2 = await runTier2(req.url, handle, session, remaining, sanitizedHeaders, req.method, req.body)
+      const t2 = await (runners.tier2 ?? runTier2)(
+        req.url,
+        handle,
+        session,
+        remaining,
+        sanitizedHeaders,
+        req.method,
+        req.body,
+      )
       emit(t2)
       if (hasUsablePayload(t2)) {
         if (t2.cookies && t2.cookies.length > 0) {
@@ -148,7 +172,15 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     let t3: Awaited<ReturnType<typeof runTier3>>
     for (let attempt = 0; ; attempt++) {
       const remaining3 = maxTimeout - (Date.now() - totalStart)
-      t3 = await runTier3(req.url, handle, remaining3, proxy3, sanitizedHeaders, req.method, req.body)
+      t3 = await (runners.tier3 ?? runTier3)(
+        req.url,
+        handle,
+        remaining3,
+        proxy3,
+        sanitizedHeaders,
+        req.method,
+        req.body,
+      )
 
       const pool = deps.proxyPool
       if (t3.status !== "blocked" || req.proxy || !proxy3 || !pool || attempt + 1 >= MAX_PROXY_ATTEMPTS) break
@@ -163,7 +195,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     emit(t3)
     if (hasUsablePayload(t3)) {
       const cookies: Cookie[] = t3.cookies ?? []
-      if (cookies.length > 0) {
+      if (cookies.length > 0 && !explicitProxy) {
         await deps.saveSession(domain, {
           cookies,
           userAgent: t3.userAgent ?? handle.fingerprint.userAgent,
@@ -203,7 +235,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     }
 
     let t4: Awaited<ReturnType<typeof runTier4>>
-    const { runTier4: runTier4Lazy } = await import("./tiers/4")
+    const runTier4Lazy = runners.tier4 ?? (await import("./tiers/4")).runTier4
     for (let attempt = 0; ; attempt++) {
       console.log(`[orchestrator] Tier 4 via residential proxy: ${proxy4.replace(/\/\/[^@]*@/, "//**@")}`)
       const remaining4 = maxTimeout - (Date.now() - totalStart)
@@ -219,7 +251,7 @@ export async function scrape(req: ScrapeRequest, deps: OrchestratorDeps): Promis
     emit(t4)
     if (hasUsablePayload(t4)) {
       const cookies: Cookie[] = t4.cookies ?? []
-      if (cookies.length > 0) {
+      if (cookies.length > 0 && !explicitProxy) {
         await deps.saveSession(domain, {
           cookies,
           userAgent: t4.userAgent ?? handle.fingerprint.userAgent,

--- a/packages/tiers/src/tiers/1.ts
+++ b/packages/tiers/src/tiers/1.ts
@@ -12,6 +12,7 @@ import {
   isCloudflarePage,
 } from "../utils/detect"
 import { normalizeHtml } from "../utils/html"
+import { normalizeProxyError, proxyResponseFailure } from "../utils/proxyFailure"
 import { isTextContentType } from "../utils/response"
 
 export interface Tier1Result extends TierResult {
@@ -33,6 +34,7 @@ export async function runTier1(
   extraHeaders?: Record<string, string>,
   method?: string,
   body?: string,
+  proxy?: string,
 ): Promise<Tier1Result> {
   const start = Date.now()
   try {
@@ -50,6 +52,7 @@ export async function runTier1(
         ...extraHeaders,
       },
       redirect: "follow",
+      ...(proxy ? { proxy } : {}),
     })
 
     // AWS WAF's action header is authoritative when paired with its documented
@@ -62,6 +65,19 @@ export async function runTier1(
     const setCookies = res.headers.getSetCookie()
     if (setCookies.length > 0) responseHeaders["set-cookie"] = setCookies.join("\n")
     const contentType = responseHeaders["content-type"] ?? "application/octet-stream"
+    const proxyFailure = proxy ? proxyResponseFailure(res.status, responseHeaders) : undefined
+    if (proxyFailure) {
+      return {
+        tier: 1,
+        status: "error",
+        durationMs: Date.now() - start,
+        reason: proxyFailure,
+        responseHeaders,
+        contentType,
+        body: new Uint8Array(),
+        statusCode: res.status,
+      }
+    }
     const awsAction = getAwsWafAction(res.status, responseHeaders)
     if (awsAction) {
       return {
@@ -215,7 +231,7 @@ export async function runTier1(
       tier: 1,
       status: "error",
       durationMs: Date.now() - start,
-      reason: err instanceof Error ? err.message : String(err),
+      reason: proxy ? normalizeProxyError(err) : err instanceof Error ? err.message : String(err),
     }
   }
 }

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -15,6 +15,7 @@ import {
 import { normalizeHtml } from "../utils/html"
 import { trackMainDocumentResponses } from "../utils/mainResponse"
 import { isHardNetworkFailure } from "../utils/network"
+import { isProxyTransportFailure, normalizeProxyError, proxyResponseFailure } from "../utils/proxyFailure"
 import { captureResponse, isTextContentType } from "../utils/response"
 import type { RouteLike } from "../utils/sanitize"
 import { routeContinueOverrides } from "../utils/sanitize"
@@ -81,7 +82,17 @@ export async function runTier3(
 
     // Abort early on hard network failures — no point running challenge wait
     if (isHardNetworkFailure(gotoErr)) {
-      return { tier: 3, status: "error", durationMs: Date.now() - start, reason: gotoErr.message.split("\n")[0] }
+      return {
+        tier: 3,
+        status: "error",
+        durationMs: Date.now() - start,
+        reason:
+          proxyUrl && isProxyTransportFailure(gotoErr) ? normalizeProxyError(gotoErr) : gotoErr.message.split("\n")[0],
+      }
+    }
+    const earlyProxyFailure = proxyUrl ? proxyResponseFailure(mainResponse.status, mainResponse.headers) : undefined
+    if (earlyProxyFailure) {
+      return { tier: 3, status: "error", durationMs: Date.now() - start, reason: earlyProxyFailure }
     }
     // Otherwise (navigation interrupted by CF redirect) — fall through and keep going
 
@@ -147,8 +158,11 @@ export async function runTier3(
     // instead of hitting the isHardFail regex (which only matches Chromium ERR_* strings),
     // so we still need to catch the resulting about:neterror page here.
     if (isBrowserErrorPage(html)) {
-      const errMsg =
-        gotoErr instanceof Error ? gotoErr.message.split("\n")[0] : "browser network error (about:neterror)"
+      const errMsg = proxyUrl
+        ? "proxy-connection-failed"
+        : gotoErr instanceof Error
+          ? gotoErr.message.split("\n")[0]
+          : "browser network error (about:neterror)"
       return { tier: 3, status: "error", durationMs: Date.now() - start, reason: errMsg }
     }
 
@@ -205,7 +219,12 @@ export async function runTier3(
       tier: 3,
       status: "error",
       durationMs: Date.now() - start,
-      reason: err instanceof Error ? err.message : String(err),
+      reason:
+        proxyUrl && isProxyTransportFailure(err)
+          ? normalizeProxyError(err)
+          : err instanceof Error
+            ? err.message
+            : String(err),
     }
   } finally {
     // Closing the context closes all of its pages. If Firefox wedges during cleanup,

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -15,6 +15,7 @@ import {
 import { normalizeHtml } from "../utils/html"
 import { trackMainDocumentResponses } from "../utils/mainResponse"
 import { isHardNetworkFailure } from "../utils/network"
+import { isProxyTransportFailure, normalizeProxyError, proxyResponseFailure } from "../utils/proxyFailure"
 import { captureResponse, isTextContentType } from "../utils/response"
 import type { RouteLike } from "../utils/sanitize"
 import { routeContinueOverrides } from "../utils/sanitize"
@@ -79,7 +80,11 @@ export async function runTier4(
       .catch((e: Error) => e)
 
     if (isHardNetworkFailure(gotoErr)) {
-      return { tier: 4, status: "error", durationMs: Date.now() - start, reason: gotoErr.message.split("\n")[0] }
+      return { tier: 4, status: "error", durationMs: Date.now() - start, reason: normalizeProxyError(gotoErr) }
+    }
+    const earlyProxyFailure = proxyResponseFailure(mainResponse.status, mainResponse.headers)
+    if (earlyProxyFailure) {
+      return { tier: 4, status: "error", durationMs: Date.now() - start, reason: earlyProxyFailure }
     }
 
     const remaining = maxTimeout - (Date.now() - start)
@@ -131,7 +136,7 @@ export async function runTier4(
         tier: 4,
         status: "error",
         durationMs: Date.now() - start,
-        reason: "browser network error (about:neterror)",
+        reason: "proxy-connection-failed",
       }
     }
 
@@ -194,7 +199,11 @@ export async function runTier4(
       tier: 4,
       status: "error",
       durationMs: Date.now() - start,
-      reason: err instanceof Error ? err.message : String(err),
+      reason: isProxyTransportFailure(err)
+        ? normalizeProxyError(err)
+        : err instanceof Error
+          ? err.message
+          : String(err),
     }
   } finally {
     await closeTemporaryContext(state.proxyContext, handle.requestBrowserReplacement, "tier4 context cleanup timed out")

--- a/packages/tiers/src/utils/network.ts
+++ b/packages/tiers/src/utils/network.ts
@@ -2,7 +2,7 @@
 // handling before this extraction. These are Chromium/Playwright ERR_* strings that mean
 // the browser never reached a server, so there's no point running challenge-wait logic.
 const HARD_NETWORK_FAILURE =
-  /ERR_NAME_NOT_RESOLVED|ERR_CONNECTION_REFUSED|ERR_CONNECTION_TIMED_OUT|ERR_TUNNEL_CONNECTION_FAILED|ERR_PROXY_CONNECTION_FAILED/i
+  /ERR_NAME_NOT_RESOLVED|ERR_CONNECTION_REFUSED|ERR_CONNECTION_TIMED_OUT|ERR_TUNNEL_CONNECTION_FAILED|ERR_PROXY_CONNECTION_FAILED|NS_ERROR_[A-Z_]*(?:PROXY|CONNECTION|NET_TIMEOUT|UNKNOWN_HOST)/i
 
 export function isHardNetworkFailure(err: unknown): err is Error {
   return err instanceof Error && HARD_NETWORK_FAILURE.test(err.message)

--- a/packages/tiers/src/utils/proxyFailure.ts
+++ b/packages/tiers/src/utils/proxyFailure.ts
@@ -1,0 +1,25 @@
+const PROXY_TRANSPORT_FAILURE =
+  /proxy|tunnel|connect(?:ion)? (?:refused|reset|closed|failed|timed out)|tls|ssl|certificate|unexpected eof|socket hang up|ECONN(?:REFUSED|RESET)|EPROTO|NS_ERROR_[A-Z_]*PROXY/i
+
+export function hasProxyStatusError(headers: Record<string, string>): boolean {
+  const value = headers["proxy-status"]
+  return value !== undefined && /(?:^|[;,]\s*)error\s*=/i.test(value)
+}
+
+export function proxyResponseFailure(
+  status: number,
+  headers: Record<string, string>,
+): "proxy-authentication-failed" | "proxy-connection-failed" | undefined {
+  if (status === 407) return "proxy-authentication-failed"
+  if (hasProxyStatusError(headers)) return "proxy-connection-failed"
+  return undefined
+}
+
+export function normalizeProxyError(err: unknown): "proxy-authentication-failed" | "proxy-connection-failed" {
+  const message = err instanceof Error ? err.message : String(err)
+  return /407|proxy authentication/i.test(message) ? "proxy-authentication-failed" : "proxy-connection-failed"
+}
+
+export function isProxyTransportFailure(err: unknown): boolean {
+  return err instanceof Error && PROXY_TRANSPORT_FAILURE.test(err.message)
+}

--- a/packages/tiers/tests/browserProxyFailure.test.ts
+++ b/packages/tiers/tests/browserProxyFailure.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import type { BrowserHandle } from "@trawl/browser"
+import { runTier3 } from "../src/tiers/3"
+import { runTier4 } from "../src/tiers/4"
+
+function handleWithNavigationError(message: string): BrowserHandle {
+  const page = {
+    route: async () => {},
+    on: () => {},
+    mainFrame: () => ({}),
+    goto: async () => {
+      throw new Error(message)
+    },
+  }
+  const context = {
+    addInitScript: async () => {},
+    newPage: async () => page,
+    cookies: async () => [],
+    close: async () => {},
+  }
+  return {
+    id: 1,
+    lease: 1,
+    context: context as BrowserHandle["context"],
+    browser: { newContext: async () => context } as BrowserHandle["browser"],
+    fingerprint: { userAgent: "test", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+  }
+}
+
+function handleWithBrowserErrorPage(): BrowserHandle {
+  const context = {
+    addInitScript: async () => {},
+    cookies: async () => [],
+    close: async () => {},
+    newPage: async () => page,
+  }
+  const page = {
+    route: async () => {},
+    on: () => {},
+    mainFrame: () => page,
+    goto: async () => undefined,
+    content: async () =>
+      '<html><head><title data-l10n-id="neterror-page-title">Problem loading page</title></head><body>proxy failed</body></html>',
+    title: async () => "Problem loading page",
+    url: () => "about:neterror?e=proxyConnectFailure",
+    frames: () => [],
+    waitForLoadState: async () => {},
+    context: () => context,
+  }
+  return {
+    id: 1,
+    lease: 1,
+    context: context as BrowserHandle["context"],
+    browser: { newContext: async () => context } as BrowserHandle["browser"],
+    fingerprint: { userAgent: "test", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+  }
+}
+
+describe("browser proxy network failures", () => {
+  test("normalizes Chromium proxy failures in Tier 3", async () => {
+    const result = await runTier3(
+      "https://target.example",
+      handleWithNavigationError("page.goto: net::ERR_TUNNEL_CONNECTION_FAILED"),
+      1_000,
+      "http://proxy.example:8080",
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toBe("proxy-connection-failed")
+  })
+
+  test("normalizes Firefox proxy failures in Tier 3", async () => {
+    const result = await runTier3(
+      "https://target.example",
+      handleWithNavigationError("NS_ERROR_PROXY_CONNECTION_REFUSED"),
+      1_000,
+      "http://proxy.example:8080",
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toBe("proxy-connection-failed")
+  })
+
+  test("normalizes Firefox proxy failures in Tier 4", async () => {
+    const result = await runTier4(
+      "https://target.example",
+      handleWithNavigationError("NS_ERROR_PROXY_BAD_GATEWAY"),
+      1_000,
+      "socks5://proxy.example:1080",
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toBe("proxy-connection-failed")
+  })
+
+  test("retains origin network errors when Tier 3 is direct", async () => {
+    const result = await runTier3(
+      "https://target.example",
+      handleWithNavigationError("page.goto: net::ERR_CONNECTION_REFUSED"),
+      1_000,
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toContain("ERR_CONNECTION_REFUSED")
+  })
+
+  test("Tier 3 never returns Firefox's proxy error page as successful content", async () => {
+    const result = await runTier3(
+      "https://target.example",
+      handleWithBrowserErrorPage(),
+      1_500,
+      "http://proxy.example:8080",
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toBe("proxy-connection-failed")
+    expect(result.html).toBeUndefined()
+  })
+
+  test("Tier 4 never returns Firefox's proxy error page as successful content", async () => {
+    const result = await runTier4(
+      "https://target.example",
+      handleWithBrowserErrorPage(),
+      1_500,
+      "http://proxy.example:8080",
+    )
+    expect(result.status).toBe("error")
+    expect(result.reason).toBe("proxy-connection-failed")
+    expect(result.html).toBeUndefined()
+  })
+})

--- a/packages/tiers/tests/explicitProxyRouting.test.ts
+++ b/packages/tiers/tests/explicitProxyRouting.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, test } from "bun:test"
+import type { BrowserHandle } from "@trawl/browser"
+import { type OrchestratorDeps, ScrapeError, scrape } from "../src/orchestrator"
+
+function unusedBrowserDeps(overrides: Partial<OrchestratorDeps> = {}): OrchestratorDeps {
+  return {
+    acquireBrowser: async () => {
+      throw new Error("browser should not be acquired")
+    },
+    releaseBrowser: () => {},
+    loadSession: async () => undefined,
+    saveSession: async () => {},
+    invalidateSession: async () => {},
+    ...overrides,
+  }
+}
+
+describe("explicit proxy routing", () => {
+  test("routes Tier 1 through an HTTP proxy without reaching the target directly", async () => {
+    let targetRequests = 0
+    let proxyRequests = 0
+    const target = Bun.serve({
+      port: 0,
+      fetch: () => {
+        targetRequests++
+        return new Response("<html>direct</html>", { headers: { "content-type": "text/html" } })
+      },
+    })
+    const proxy = Bun.serve({
+      port: 0,
+      fetch: () => {
+        proxyRequests++
+        return new Response("<html>proxy sentinel</html>", { headers: { "content-type": "text/html" } })
+      },
+    })
+
+    try {
+      const result = await scrape(
+        { url: target.url.toString(), maxTier: 1, proxy: proxy.url.toString() },
+        unusedBrowserDeps(),
+      )
+      expect(result.tier).toBe(1)
+      expect(result.proxyUsed).toBeTrue()
+      expect(result.html).toContain("proxy sentinel")
+      expect(proxyRequests).toBe(1)
+      expect(targetRequests).toBe(0)
+    } finally {
+      proxy.stop(true)
+      target.stop(true)
+    }
+  })
+
+  test("never invokes direct Tier 1 for an explicit SOCKS proxy", async () => {
+    const originalFetch = globalThis.fetch
+    let fetchCalls = 0
+    globalThis.fetch = (async () => {
+      fetchCalls++
+      throw new Error("direct fetch must not run")
+    }) as typeof fetch
+    try {
+      await expect(
+        scrape(
+          { url: "https://target.example", maxTier: 1, proxy: "socks5://proxy.example:1080" },
+          unusedBrowserDeps(),
+        ),
+      ).rejects.toBeInstanceOf(ScrapeError)
+      expect(fetchCalls).toBe(0)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test.each([
+    [407, {}, "proxy-authentication-failed"],
+    [502, { "proxy-status": "fake-proxy; error=connection_timeout" }, "proxy-connection-failed"],
+  ] as const)("fails immediately for definitive proxy response status %i", async (status, headers, reason) => {
+    const proxy = Bun.serve({
+      port: 0,
+      fetch: () => new Response("proxy failure", { status, headers }),
+    })
+    try {
+      const failure = scrape({ url: "https://target.example", proxy: proxy.url.toString() }, unusedBrowserDeps()).catch(
+        (error: unknown) => error,
+      )
+      const error = await failure
+      expect(error).toBeInstanceOf(ScrapeError)
+      expect((error as ScrapeError).message).toBe(reason)
+      expect((error as ScrapeError).timings[0]?.reason).toBe(reason)
+    } finally {
+      proxy.stop(true)
+    }
+  })
+
+  test("fails instead of falling back direct when the explicit proxy is unreachable", async () => {
+    const error = await scrape(
+      { url: "https://target.example", proxy: "http://127.0.0.1:1" },
+      unusedBrowserDeps(),
+    ).catch((failure: unknown) => failure)
+    expect(error).toBeInstanceOf(ScrapeError)
+    expect((error as ScrapeError).message).toBe("proxy-connection-failed")
+  })
+
+  test("normalizes an HTTP/HTTPS proxy protocol mismatch", async () => {
+    const plainHttpProxy = Bun.serve({
+      port: 0,
+      fetch: () => new Response("plain HTTP only"),
+    })
+    try {
+      const wrongProtocolUrl = plainHttpProxy.url.toString().replace("http:", "https:")
+      const error = await scrape({ url: "https://target.example", proxy: wrongProtocolUrl }, unusedBrowserDeps()).catch(
+        (failure: unknown) => failure,
+      )
+      expect(error).toBeInstanceOf(ScrapeError)
+      expect((error as ScrapeError).message).toBe("proxy-connection-failed")
+    } finally {
+      plainHttpProxy.stop(true)
+    }
+  })
+
+  test("does not load an unproxied Tier 2 session", async () => {
+    let loadCalls = 0
+    let released = false
+    const handle = { id: 7, lease: 11 } as BrowserHandle
+    const deps = unusedBrowserDeps({
+      acquireBrowser: async () => handle,
+      releaseBrowser: () => {
+        released = true
+      },
+      loadSession: async () => {
+        loadCalls++
+        return { cookies: [], userAgent: "cached", savedAt: Date.now() }
+      },
+    })
+
+    await expect(
+      scrape(
+        {
+          url: "https://target.example",
+          skipHttp: true,
+          maxTier: 2,
+          proxy: "http://proxy.example:8080",
+        },
+        deps,
+      ),
+    ).rejects.toBeInstanceOf(ScrapeError)
+    expect(loadCalls).toBe(0)
+    expect(released).toBeTrue()
+  })
+
+  test("does not save explicit-proxy cookies into the domain session cache", async () => {
+    let saveCalls = 0
+    const handle = {
+      id: 7,
+      lease: 11,
+      fingerprint: { userAgent: "browser", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+    } as BrowserHandle
+    const deps = unusedBrowserDeps({
+      acquireBrowser: async () => handle,
+      releaseBrowser: () => {},
+      saveSession: async () => {
+        saveCalls++
+      },
+    })
+
+    const result = await scrape(
+      {
+        url: "https://target.example",
+        skipHttp: true,
+        maxTier: 3,
+        proxy: "http://proxy.example:8080",
+      },
+      deps,
+      {
+        tier3: async () => ({
+          tier: 3,
+          status: "success",
+          durationMs: 1,
+          html: "<html>proxied</html>",
+          cookies: [
+            {
+              name: "proxy-cookie",
+              value: "secret",
+              domain: "target.example",
+              path: "/",
+              expires: -1,
+              httpOnly: false,
+              secure: true,
+            },
+          ],
+          userAgent: "proxied-browser",
+          statusCode: 200,
+        }),
+      },
+    )
+
+    expect(result.tier).toBe(3)
+    expect(result.proxyUsed).toBeTrue()
+    expect(saveCalls).toBe(0)
+  })
+
+  test("does not save explicit-proxy Tier 4 cookies into the domain session cache", async () => {
+    let saveCalls = 0
+    const handle = {
+      id: 7,
+      lease: 11,
+      fingerprint: { userAgent: "browser", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+    } as BrowserHandle
+    const deps = unusedBrowserDeps({
+      acquireBrowser: async () => handle,
+      releaseBrowser: () => {},
+      saveSession: async () => {
+        saveCalls++
+      },
+    })
+
+    const result = await scrape(
+      {
+        url: "https://target.example",
+        skipHttp: true,
+        proxy: "http://proxy.example:8080",
+      },
+      deps,
+      {
+        tier3: async () => ({ tier: 3, status: "blocked", durationMs: 1, reason: "proxy-ip-blocked" }),
+        tier4: async () => ({
+          tier: 4,
+          status: "success",
+          durationMs: 1,
+          html: "<html>proxied Tier 4</html>",
+          cookies: [
+            {
+              name: "proxy-cookie",
+              value: "secret",
+              domain: "target.example",
+              path: "/",
+              expires: -1,
+              httpOnly: false,
+              secure: true,
+            },
+          ],
+          statusCode: 200,
+        }),
+      },
+    )
+
+    expect(result.tier).toBe(4)
+    expect(result.proxyUsed).toBeTrue()
+    expect(saveCalls).toBe(0)
+  })
+
+  test("retains the cached Tier 2 fast path without an explicit proxy", async () => {
+    let loadCalls = 0
+    const handle = {
+      id: 7,
+      lease: 11,
+      fingerprint: { userAgent: "browser", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+    } as BrowserHandle
+    const deps = unusedBrowserDeps({
+      acquireBrowser: async () => handle,
+      releaseBrowser: () => {},
+      loadSession: async () => {
+        loadCalls++
+        return { cookies: [], userAgent: "cached-browser", savedAt: Date.now() }
+      },
+    })
+
+    const result = await scrape({ url: "https://target.example", skipHttp: true, maxTier: 2 }, deps, {
+      tier2: async () => ({
+        tier: 2,
+        status: "success",
+        durationMs: 1,
+        html: "<html>cached</html>",
+        statusCode: 200,
+      }),
+    })
+
+    expect(result.tier).toBe(2)
+    expect(result.sessionCached).toBeTrue()
+    expect(result.proxyUsed).toBeFalse()
+    expect(loadCalls).toBe(1)
+  })
+
+  test("retains session persistence for configured-pool escalation", async () => {
+    let saveCalls = 0
+    const handle = {
+      id: 7,
+      lease: 11,
+      fingerprint: { userAgent: "browser", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+    } as BrowserHandle
+    const deps = unusedBrowserDeps({
+      acquireBrowser: async () => handle,
+      releaseBrowser: () => {},
+      saveSession: async () => {
+        saveCalls++
+      },
+      proxyPool: { next: () => "http://pool.example:8080", markBad: () => {} } as OrchestratorDeps["proxyPool"],
+    })
+
+    const result = await scrape({ url: "https://target.example", skipHttp: true, maxTier: 3 }, deps, {
+      tier3: async () => ({
+        tier: 3,
+        status: "success",
+        durationMs: 1,
+        html: "<html>pool</html>",
+        cookies: [
+          {
+            name: "pool-cookie",
+            value: "ok",
+            domain: "target.example",
+            path: "/",
+            expires: -1,
+            httpOnly: false,
+            secure: true,
+          },
+        ],
+        statusCode: 200,
+      }),
+    })
+
+    expect(result.proxyUsed).toBeTrue()
+    expect(saveCalls).toBe(1)
+  })
+})

--- a/packages/tiers/tests/proxyFailure.test.ts
+++ b/packages/tiers/tests/proxyFailure.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { isProxyTransportFailure, proxyResponseFailure } from "../src/utils/proxyFailure"
+
+describe("proxy failure classification", () => {
+  test("only treats Proxy-Status with an error parameter as failure", () => {
+    expect(proxyResponseFailure(200, { "proxy-status": 'ExampleProxy; next-hop="origin.example"' })).toBeUndefined()
+    expect(proxyResponseFailure(502, { "proxy-status": "ExampleProxy; error=dns_error" })).toBe(
+      "proxy-connection-failed",
+    )
+  })
+
+  test("recognizes Chromium and Firefox proxy network errors", () => {
+    expect(isProxyTransportFailure(new Error("net::ERR_TUNNEL_CONNECTION_FAILED"))).toBeTrue()
+    expect(isProxyTransportFailure(new Error("NS_ERROR_PROXY_CONNECTION_REFUSED"))).toBeTrue()
+  })
+})

--- a/packages/tiers/tests/runTier1Post.test.ts
+++ b/packages/tiers/tests/runTier1Post.test.ts
@@ -37,6 +37,58 @@ afterEach(() => {
 })
 
 describe("runTier1 — POST support", () => {
+  test("passes an explicit HTTP proxy to Bun fetch", async () => {
+    const restore = installFetchMock()
+    try {
+      const result = await runTier1("https://target.example/x", undefined, undefined, undefined, "http://proxy:8080")
+      expect(result.status).toBe("success")
+      expect((recorded[0].init as RequestInit & { proxy?: string }).proxy).toBe("http://proxy:8080")
+    } finally {
+      restore()
+    }
+  })
+
+  test("normalizes proxy authentication and Proxy-Status failures", async () => {
+    let restore = installFetchMock(
+      () => new Response("proxy auth", { status: 407, headers: { "content-type": "text/plain" } }),
+    )
+    try {
+      const result = await runTier1("https://target.example/x", undefined, undefined, undefined, "http://proxy:8080")
+      expect(result.status).toBe("error")
+      expect(result.reason).toBe("proxy-authentication-failed")
+    } finally {
+      restore()
+    }
+
+    restore = installFetchMock(
+      () =>
+        new Response("upstream failed", {
+          status: 502,
+          headers: { "content-type": "text/plain", "proxy-status": "proxy.example; error=connection_timeout" },
+        }),
+    )
+    try {
+      const result = await runTier1("https://target.example/x", undefined, undefined, undefined, "http://proxy:8080")
+      expect(result.status).toBe("error")
+      expect(result.reason).toBe("proxy-connection-failed")
+    } finally {
+      restore()
+    }
+  })
+
+  test("normalizes an explicit proxy transport failure", async () => {
+    const restore = installFetchMock(() => {
+      throw new Error("TLS connection aborted")
+    })
+    try {
+      const result = await runTier1("https://target.example/x", undefined, undefined, undefined, "https://proxy:1001")
+      expect(result.status).toBe("error")
+      expect(result.reason).toBe("proxy-connection-failed")
+    } finally {
+      restore()
+    }
+  })
+
   test("uses GET with no body when method is omitted", async () => {
     const restore = installFetchMock()
     try {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,7 +25,7 @@ export interface ScrapeRequest {
   headers?: Record<string, string>
   method?: SupportedMethod
   body?: string
-  // Per-request proxy override — bypasses the server-configured proxy pool for this call.
+  // Strict per-request route: target traffic must use this proxy and never fall back direct.
   proxy?: string
 }
 
@@ -47,7 +47,7 @@ export interface ScrapeResult {
   timings: TierResult[]
   totalMs: number
   captchasSolved?: string[] // captcha types solved during this request (e.g. ['turnstile', 'recaptcha-v2'])
-  proxyUsed?: boolean // true if the winning tier routed through a proxy (Tier 3 datacenter pool or Tier 4 residential pool/override)
+  proxyUsed?: boolean // true if the winning tier routed through a proxy (Tier 1, 3, or 4)
   // Raw response payload — populated by all tiers when available. The MITM proxy
   // (:8192) consumes this; /scrape and FlareSolverr /v1 still rely on `html` only.
   // Binary content (images, .torrent, videos) MUST use this field — `html` would


### PR DESCRIPTION
## Summary

Treats an explicit request-level `proxy` as a strict routing guarantee, preventing requests from silently falling back to direct Tier 1 or the unproxied Tier 2 session cache. Proxy authentication, connection, protocol, `Proxy-Status`, and browser network failures now return an error instead of successful content.

## Linked issues

Closes #73 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only

## Checklist

- [x] I opened or commented on an issue before starting this PR (non-trivial changes only)
- [x] I ran `bun run check` and it passes locally
- [x] I added or updated tests for the behavior change (if applicable)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` for user-visible changes
- [x] I read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under [AGPL-3.0](LICENSE)