### PR TITLE
test(datadome): close headful acceptance gaps

### DIFF
--- a/apps/api/src/deps.test.ts
+++ b/apps/api/src/deps.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import type { BrowserPool } from "@trawl/browser"
+import type { BrowserHandle } from "@trawl/types"
+import { getDeps, getHeadfulPool, initPool, shutdownPools } from "./deps"
+
+const handle = (headful: boolean): BrowserHandle => ({
+  id: 0,
+  lease: headful ? 2 : 1,
+  headful,
+  context: {},
+  browser: {},
+  fingerprint: { userAgent: "test", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" },
+})
+
+function poolFactory(options: { failHeadful?: boolean } = {}) {
+  const pools: Array<{
+    headful: boolean
+    events: string[]
+    releases: Array<[number, number | undefined]>
+    pool: BrowserPool
+  }> = []
+  const createPool = (config: ConstructorParameters<typeof BrowserPool>[0]): BrowserPool => {
+    const headful = config.virtualDisplay === true
+    const record = { headful, events: [] as string[], releases: [] as Array<[number, number | undefined]> }
+    const pool = {
+      init: async () => {
+        record.events.push("init")
+        if (headful && options.failHeadful) throw new Error("xvfb launch failed")
+      },
+      startHealthCheck: () => record.events.push("health"),
+      shutdown: async () => record.events.push("shutdown"),
+      acquire: async () => handle(headful),
+      release: (id: number, lease?: number) => record.releases.push([id, lease]),
+      getStats: () => ({ total: 1, busy: 0, available: 1, restarts: 0, avgRestarts: 0, stalled: 0, live: 1 }),
+    } as unknown as BrowserPool
+    pools.push({ ...record, pool })
+    return pool
+  }
+  return { pools, createPool }
+}
+
+describe("browser pool dependencies", () => {
+  test("disabled headful configuration starts only the main pool and fails headful acquisition clearly", async () => {
+    const factory = poolFactory()
+    await initPool({ poolSize: 1, headfulPoolSize: 0, createPool: factory.createPool, initCache: async () => {} })
+
+    expect(factory.pools).toHaveLength(1)
+    expect(factory.pools[0]?.events).toEqual(["init", "health"])
+    expect(getHeadfulPool()).toBeUndefined()
+    await expect(getDeps().acquireBrowser("example.test", 100, { headful: true })).rejects.toThrow(
+      "BROWSER_HEADFUL_POOL_SIZE greater than 0",
+    )
+    await shutdownPools()
+  })
+
+  test("starts and shuts down both pools and returns equal-id handles to their owner", async () => {
+    const factory = poolFactory()
+    await initPool({ poolSize: 1, headfulPoolSize: 1, createPool: factory.createPool, initCache: async () => {} })
+    const deps = getDeps()
+    const headless = await deps.acquireBrowser("example.test", 100, { headful: false })
+    const headful = await deps.acquireBrowser("example.test", 100, { headful: true })
+
+    expect(headless.id).toBe(headful.id)
+    deps.releaseBrowser(headless)
+    deps.releaseBrowser(headful)
+    expect(factory.pools[0]?.releases).toEqual([[0, 1]])
+    expect(factory.pools[1]?.releases).toEqual([[0, 2]])
+
+    await shutdownPools()
+    expect(factory.pools[0]?.events).toEqual(["init", "health", "shutdown"])
+    expect(factory.pools[1]?.events).toEqual(["init", "health", "shutdown"])
+  })
+
+  test("a headful launch failure closes both pools and rejects startup", async () => {
+    const factory = poolFactory({ failHeadful: true })
+    await expect(
+      initPool({ poolSize: 1, headfulPoolSize: 1, createPool: factory.createPool, initCache: async () => {} }),
+    ).rejects.toThrow("xvfb launch failed")
+    expect(factory.pools[0]?.events).toEqual(["init", "health", "shutdown"])
+    expect(factory.pools[1]?.events).toEqual(["init", "shutdown"])
+  })
+})

--- a/apps/api/src/deps.ts
+++ b/apps/api/src/deps.ts
@@ -24,6 +24,15 @@ const state: {
 
 const handleOwners = new WeakMap<object, BrowserPool>()
 
+type BrowserPoolOptions = ConstructorParameters<typeof BrowserPool>[0]
+
+interface InitPoolOptions {
+  poolSize?: number
+  headfulPoolSize?: number
+  createPool?: (options: BrowserPoolOptions) => BrowserPool
+  initCache?: () => Promise<void>
+}
+
 export const getPool = () => state.pool
 export const getHeadfulPool = () => state.headfulPool
 
@@ -42,9 +51,18 @@ const initSessionCache = async (): Promise<void> => {
   }
 }
 
-export const initPool = async (): Promise<void> => {
-  const pool = new BrowserPool({
-    poolSize: POOL_SIZE,
+export const shutdownPools = async (): Promise<void> => {
+  await Promise.all([state.pool?.shutdown(), state.headfulPool?.shutdown()])
+}
+
+export const initPool = async ({
+  poolSize = POOL_SIZE,
+  headfulPoolSize = HEADFUL_POOL_SIZE,
+  createPool = (options) => new BrowserPool(options),
+  initCache = initSessionCache,
+}: InitPoolOptions = {}): Promise<void> => {
+  const pool = createPool({
+    poolSize,
     acquireTimeoutMs: ACQUIRE_TIMEOUT_MS,
     recycleAfterTemporaryContexts: RECYCLE_AFTER_TEMPORARY_CONTEXTS,
     contentProcesses: CONTENT_PROCESSES,
@@ -53,9 +71,10 @@ export const initPool = async (): Promise<void> => {
     launchTimeoutMs: LAUNCH_TIMEOUT_MS,
   })
 
-  if (HEADFUL_POOL_SIZE > 0) {
-    state.headfulPool = new BrowserPool({
-      poolSize: HEADFUL_POOL_SIZE,
+  state.headfulPool = undefined
+  if (headfulPoolSize > 0) {
+    state.headfulPool = createPool({
+      poolSize: headfulPoolSize,
       acquireTimeoutMs: ACQUIRE_TIMEOUT_MS,
       recycleAfterTemporaryContexts: RECYCLE_AFTER_TEMPORARY_CONTEXTS,
       contentProcesses: CONTENT_PROCESSES,
@@ -71,19 +90,19 @@ export const initPool = async (): Promise<void> => {
   state.pool = pool
 
   try {
-    await Promise.all([initSessionCache(), pool.init()])
+    await Promise.all([initCache(), pool.init()])
     pool.startHealthCheck()
     if (state.headfulPool) {
       await state.headfulPool.init()
       state.headfulPool.startHealthCheck()
-      console.log(`[api] headful pool warm (${HEADFUL_POOL_SIZE} browser${HEADFUL_POOL_SIZE === 1 ? "" : "s"})`)
+      console.log(`[api] headful pool warm (${headfulPoolSize} browser${headfulPoolSize === 1 ? "" : "s"})`)
     }
   } catch (error) {
     await Promise.all([pool.shutdown(), state.headfulPool?.shutdown()])
     throw error
   }
 
-  console.log(`[api] ready — all ${POOL_SIZE} browser${POOL_SIZE === 1 ? "" : "s"} warm`)
+  console.log(`[api] ready — all ${poolSize} browser${poolSize === 1 ? "" : "s"} warm`)
 }
 
 export const getDeps = (): OrchestratorDeps => {

--- a/apps/api/src/lifecycle.ts
+++ b/apps/api/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import { getHeadfulPool, getPool } from "./deps"
+import { shutdownPools } from "./deps"
 
 export interface LifecycleOptions {
   onShutdown?: () => Promise<void>
@@ -27,7 +27,7 @@ export const registerLifecycleHandlers = (opts: LifecycleOptions = {}): void => 
         console.error("[api] onShutdown error:", err instanceof Error ? err.message : err)
       }
     }
-    await Promise.all([getPool()?.shutdown(), getHeadfulPool()?.shutdown()])
+    await shutdownPools()
     process.exit(0)
   }
 

--- a/apps/api/src/routes/stats.test.ts
+++ b/apps/api/src/routes/stats.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import type { PoolStats } from "@trawl/types"
+import { statsRoute } from "./stats"
+
+const stats = (overrides: Partial<PoolStats> = {}): PoolStats => ({
+  total: 1,
+  busy: 0,
+  available: 1,
+  restarts: 0,
+  avgRestarts: 0,
+  stalled: 0,
+  live: 1,
+  ...overrides,
+})
+
+describe("GET /stats", () => {
+  test("reports the optional headful pool additively", async () => {
+    const response = await statsRoute(
+      () => stats({ total: 3, available: 2, busy: 1 }),
+      () => stats({ total: 1, restarts: 2 }),
+    ).handle(new Request("http://localhost/stats"))
+
+    expect(await response.json()).toEqual({
+      browsers: 3,
+      available: 2,
+      busy: 1,
+      stalled: 0,
+      live: 1,
+      restarts: 0,
+      queueDepth: 0,
+      headful: { browsers: 1, available: 1, busy: 0, stalled: 0, live: 1, restarts: 2 },
+    })
+  })
+
+  test("uses null when headful capacity is disabled", async () => {
+    const response = await statsRoute(
+      () => stats(),
+      () => undefined,
+    ).handle(new Request("http://localhost/stats"))
+    expect((await response.json()).headful).toBeNull()
+  })
+})

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,9 +1,13 @@
+import type { PoolStats } from "@trawl/types"
 import { Elysia } from "elysia"
 import { getHeadfulPool, getPool } from "../deps"
 
-export function statsRoute() {
+export function statsRoute(
+  getMainStats = (): PoolStats | undefined => getPool()?.getStats(),
+  getHeadfulStats = (): PoolStats | undefined => getHeadfulPool()?.getStats(),
+) {
   return new Elysia().get("/stats", () => {
-    const stats = getPool()?.getStats() ?? {
+    const stats = getMainStats() ?? {
       total: 0,
       busy: 0,
       available: 0,
@@ -13,7 +17,7 @@ export function statsRoute() {
       live: 0,
     }
     // `null` means the optional pool is disabled.
-    const headful = getHeadfulPool()?.getStats()
+    const headful = getHeadfulStats()
     return {
       browsers: stats.total,
       available: stats.available,

--- a/packages/tiers/tests/headfulRouting.test.ts
+++ b/packages/tiers/tests/headfulRouting.test.ts
@@ -130,6 +130,89 @@ describe("headful pool routing", () => {
     expect(proxies).toEqual(["socks5://proxy.test:1080", "socks5://proxy.test:1080"])
   })
 
+  test("preserves the explicit HTTP proxy selected by a Tier 1 DataDome response", async () => {
+    const proxies: Array<string | undefined> = []
+    const acquired: boolean[] = []
+    const deps: OrchestratorDeps = {
+      acquireBrowser: async (_domain, _budget, options) => {
+        const headful = options?.headful === true
+        acquired.push(headful)
+        return browserHandle(headful)
+      },
+      releaseBrowser: () => {},
+      loadSession: async () => undefined,
+      saveSession: async () => {},
+      invalidateSession: async () => {},
+    }
+    const result = await scrape({ url: "http://target.invalid/datadome", maxTier: 3, proxy: baseUrl }, deps, {
+      tier3: async (_url, _handle, _timeout, proxy) => {
+        proxies.push(proxy)
+        return { tier: 3, status: "success", durationMs: 1, html: "<html>ok</html>", statusCode: 200 }
+      },
+    })
+    expect(result.tier).toBe(3)
+    expect(acquired).toEqual([true])
+    expect(proxies).toEqual([baseUrl])
+  })
+
+  test("preserves an explicit HTTPS proxy after Tier 1 detects DataDome", async () => {
+    const originalFetch = globalThis.fetch
+    const proxies: Array<string | undefined> = []
+    const fetchProxies: Array<string | undefined> = []
+    globalThis.fetch = (async (_input, init) => {
+      fetchProxies.push((init as (RequestInit & { proxy?: string }) | undefined)?.proxy)
+      return new Response(DATADOME_INTERSTITIAL, {
+        status: 403,
+        headers: { "content-type": "text/html", "x-dd-b": "1" },
+      })
+    }) as typeof fetch
+    const deps: OrchestratorDeps = {
+      acquireBrowser: async (_domain, _budget, options) => browserHandle(options?.headful === true),
+      releaseBrowser: () => {},
+      loadSession: async () => undefined,
+      saveSession: async () => {},
+      invalidateSession: async () => {},
+    }
+    try {
+      const result = await scrape({ url: "https://example.test", maxTier: 3, proxy: "https://proxy.test:8443" }, deps, {
+        tier3: async (_url, _handle, _timeout, proxy) => {
+          proxies.push(proxy)
+          return { tier: 3, status: "success", durationMs: 1, html: "<html>ok</html>", statusCode: 200 }
+        },
+      })
+      expect(result.tier).toBe(3)
+      expect(fetchProxies).toEqual(["https://proxy.test:8443"])
+      expect(proxies).toEqual(["https://proxy.test:8443"])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("retries Tier 3 once with the same configured datacenter proxy", async () => {
+    const proxies: Array<string | undefined> = []
+    const deps: OrchestratorDeps = {
+      acquireBrowser: async (_domain, _budget, options) => browserHandle(options?.headful === true),
+      releaseBrowser: () => {},
+      loadSession: async () => undefined,
+      saveSession: async () => {},
+      invalidateSession: async () => {},
+      proxyPool: {
+        next: () => "https://datacenter.test:8443",
+        markBad: () => {},
+      } as OrchestratorDeps["proxyPool"],
+    }
+    const result = await scrape({ url: "https://example.test", skipHttp: true, maxTier: 3 }, deps, {
+      tier3: async (_url, handle, _timeout, proxy) => {
+        proxies.push(proxy)
+        return handle.headful
+          ? { tier: 3, status: "success", durationMs: 1, html: "<html>ok</html>", statusCode: 200 }
+          : { tier: 3, status: "blocked", durationMs: 1, reason: "datadome-persistent", challenge: "datadome" }
+      },
+    })
+    expect(result.tier).toBe(3)
+    expect(proxies).toEqual(["https://datacenter.test:8443", "https://datacenter.test:8443"])
+  })
+
   test("retries late Tier 4 detection with the same residential proxy", async () => {
     const proxies: string[] = []
     const deps: OrchestratorDeps = {


### PR DESCRIPTION
## Summary

Closes the remaining acceptance gaps found during the post-merge audit of #84.

- Tests startup, disabled configuration, headful launch failure, shutdown of both pools, and handle-to-owner release when both pools use the same numeric browser ID.
- Tests additive `/stats` output and the disabled `null` state.
- Tests Tier 1 DataDome routing through explicit HTTP and HTTPS proxies, late Tier 3 detection through explicit SOCKS and configured datacenter proxies, cached Tier 2, and residential Tier 4 proxy preservation.
- Makes pool initialization injectable for deterministic tests and clears stale optional-pool state on reinitialization.
- Reuses one `shutdownPools()` path from lifecycle handling and tests.

## Validation

- `bun run verify`: passed (271 tests)
- Standard API Dockerfile: built successfully
- Baseline API Dockerfile: built successfully
- Container startup: both pools warm, `/stats.headful.live = 1`, graceful SIGTERM exit code 0
- Live smoke on `https://www.idealista.it/`, same image and egress:
  - headless Tier 3: `blocked`, `datadome-persistent`
  - startup-warmed headful API: HTTP 200 with real page in 13.37s
