### PR TITLE
fix(compose): wait for Redis readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AWS WAF Challenge support.** Detect the documented `202` Challenge and `405` CAPTCHA responses from their `x-amzn-waf-action` header, with a conservative two-marker HTML fallback. Silent challenges use a dedicated browser waiter for the domain-matching `aws-waf-token`; interactive CAPTCHA is surfaced as `aws-waf-captcha-required` for a future solver.
 
 ### Fixed
+- Wait for the bundled Redis service to pass a `PING` healthcheck before starting TRAWL, preventing a transient Compose startup race from disabling the Tier 2 session cache for the process lifetime (#90).
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
 - Preserve every upstream `Set-Cookie` field across direct, Tier 1, and browser-backed proxy responses, serializing each cookie as its own HTTP header instead of dropping or malformedly folding repeated values (#64).
 - Treat an explicit request-level `proxy` as a strict routing guarantee: route HTTP(S) Tier 1 requests through it, skip direct Tier 1 for SOCKS, bypass the unproxied Tier 2 cache, prevent proxy-derived sessions from entering the shared domain cache, disable Firefox direct failover, and surface authentication, transport, protocol, and `Proxy-Status` failures as errors instead of successful content (#73).

--- a/apps/docs/deployment/troubleshooting.md
+++ b/apps/docs/deployment/troubleshooting.md
@@ -11,9 +11,36 @@ description: Common issues and how to fix them.
 
 **Causes:**
 
-1. **Redis not reachable** — Check `REDIS_URL`. From inside Docker, use `redis://redis:6379` not `redis://localhost:6379`.
-2. **Camoufox binary not installed** — The API Dockerfile runs `bunx camoufox-js fetch`. If this step was skipped (e.g. build cache reuse), rebuild: `docker compose build --no-cache api`.
-3. **shm_size too small** — Ensure `shm_size: 1gb` is set on the API service.
+1. **Camoufox binary not installed** — The API Dockerfile runs `bunx camoufox-js fetch`. If this step was skipped (e.g. build cache reuse), rebuild: `docker compose build --no-cache api`.
+2. **shm_size too small** — Ensure `shm_size: 1gb` is set on the API service.
+
+Redis is optional at runtime. If it is unavailable, TRAWL disables the Tier 2 session-cache
+fast path but can still become ready and scrape through the other tiers.
+
+## Logs report `Tier 2 disabled`
+
+**Symptom:** TRAWL starts, but its logs contain `session cache unavailable — Tier 2 disabled` even
+though `docker compose exec redis redis-cli ping` returns `PONG`.
+
+The Redis-container check only proves that Redis is healthy now. Verify the configured URL, Docker
+DNS, and a fresh Redis connection from inside the already-running TRAWL container:
+
+```bash
+docker compose exec trawl sh -lc 'printf "%s\n" "$REDIS_URL"; getent hosts redis'
+docker compose exec trawl bun -e 'import { RedisClient } from "bun"; const client = new RedisClient(process.env.REDIS_URL); await client.connect(); console.log(await client.ping()); client.close()'
+```
+
+With the supplied Compose files, TRAWL waits for the Redis healthcheck before starting. If the
+second command returns `PONG` on a deployment that logged the warning during an earlier start,
+restart only TRAWL to enable Tier 2:
+
+```bash
+docker compose restart trawl
+```
+
+If the command fails, inspect `docker compose config` for an overridden `REDIS_URL`, custom
+`network_mode`, or networks that are not shared by the `trawl` and `redis` services. Inside Docker,
+use `redis://redis:6379`, not `redis://localhost:6379`.
 
 ### Startup timeout behind Gluetun
 

--- a/apps/web/app/components/CtaSection.vue
+++ b/apps/web/app/components/CtaSection.vue
@@ -92,6 +92,8 @@ const tabs: { id: Tab; label: string; hint: string }[] = [
   redis:
     <span class="k">image:</span> <span class="s">redis:8.8.1-alpine</span>
     <span class="k">volumes:</span> [<span class="s">redis_data:/data</span>]
+    <span class="k">healthcheck:</span>
+      <span class="k">test:</span> [<span class="s">"CMD"</span>, <span class="s">"redis-cli"</span>, <span class="s">"ping"</span>]
   trawl:
     <span class="k">image:</span> <span class="s">ghcr.io/germondai/trawl:latest</span>
     <span class="k">ports:</span>
@@ -105,7 +107,9 @@ const tabs: { id: Tab; label: string; hint: string }[] = [
       <span class="k">MITM_PROXY_CA_DIR:</span> <span class="s">/data/proxy-ca</span>
     <span class="k">volumes:</span>
       - <span class="s">trawl_proxy_ca:/data/proxy-ca</span>
-    <span class="k">depends_on:</span> [<span class="s">redis</span>]
+    <span class="k">depends_on:</span>
+      redis:
+        <span class="k">condition:</span> <span class="s">service_healthy</span>
 <span class="k">volumes:</span>
   redis_data:
   trawl_proxy_ca:</code></pre>
@@ -120,6 +124,8 @@ const tabs: { id: Tab; label: string; hint: string }[] = [
     <span class="k">image:</span> <span class="s">redis:8.8.1-alpine</span>
     <span class="k">restart:</span> <span class="s">always</span>
     <span class="k">volumes:</span> [<span class="s">redis_data:/data</span>]
+    <span class="k">healthcheck:</span>
+      <span class="k">test:</span> [<span class="s">"CMD"</span>, <span class="s">"redis-cli"</span>, <span class="s">"ping"</span>]
   trawl:
     <span class="k">image:</span> <span class="s">ghcr.io/germondai/trawl:latest</span>
     <span class="k">restart:</span> <span class="s">always</span>
@@ -135,7 +141,9 @@ const tabs: { id: Tab; label: string; hint: string }[] = [
       <span class="k">MITM_PROXY_CA_DIR:</span> <span class="s">/data/proxy-ca</span>
     <span class="k">volumes:</span>
       - <span class="s">trawl_proxy_ca:/data/proxy-ca</span>
-    <span class="k">depends_on:</span> [<span class="s">redis</span>]
+    <span class="k">depends_on:</span>
+      redis:
+        <span class="k">condition:</span> <span class="s">service_healthy</span>
     <span class="k">healthcheck:</span>
       <span class="k">test:</span> [<span class="s">"CMD"</span>, <span class="s">"curl"</span>, <span class="s">"-sf"</span>, <span class="s">"http://localhost:8191/health"</span>]
       <span class="k">interval:</span> <span class="s">30s</span>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,12 @@ services:
     restart: always
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 1s
+      retries: 10
+      start_period: 2s
 
   trawl:
     image: ghcr.io/germondai/trawl:latest
@@ -31,7 +37,8 @@ services:
     volumes:
       - trawl_proxy_ca:${MITM_PROXY_CA_DIR:-/data/proxy-ca}
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     image: redis:8.8.1-alpine
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 1s
+      retries: 10
+      start_period: 2s
 
   trawl:
     image: ghcr.io/germondai/trawl:latest
@@ -33,7 +39,8 @@ services:
       # Persist the proxy's CA so clients don't need to re-install on every restart.
       - trawl_proxy_ca:${MITM_PROXY_CA_DIR:-/data/proxy-ca}
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8191/health"]
       interval: 30s


### PR DESCRIPTION
## Summary

- add a Redis `PING` healthcheck to cached and production Compose deployments
- wait for Redis to become healthy before starting TRAWL
- document Tier 2 diagnostics and keep website Compose examples in sync

## Verification

- `bun run verify` — 271 tests, 0 failures
- both Compose files pass `docker compose config --quiet`
- delayed-start smoke test: Redis delayed by 3 seconds, Compose waited for `healthy`, then TRAWL connected Tier 2 on its first attempt
- 10/10 unmodified clean starts connected successfully before the fix, confirming this is a low-frequency race

Closes #90