### PR TITLE
fix(docker): install ffmpeg in the runtime image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libdrm2 libgbm1 \
       libasound2 \
       fonts-liberation \
+      ffmpeg \
       xvfb \
       ca-certificates \
       curl \

--- a/apps/api/Dockerfile.baseline
+++ b/apps/api/Dockerfile.baseline
@@ -124,6 +124,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libdrm2 libgbm1 \
       libasound2 \
       fonts-liberation \
+      ffmpeg \
       xvfb \
       ca-certificates unzip curl tini \
     && apt-get clean \


### PR DESCRIPTION
## Problem

The reCAPTCHA v2 and GeeTest solvers shell out to `ffmpeg` to transcode the challenge audio (MP3 → FLAC) before sending it to Google's Speech API. `packages/tiers/src/solvers/stt.ts` even documents the expectation:

```ts
// FFMPEG_PATH: full path to ffmpeg binary. Docker installs 'ffmpeg' via apt.
```

But the runtime stage of `apps/api/Dockerfile` never installs it. On `ghcr.io/germondai/trawl:latest`, every audio transcription fails:

```
[stt] audio downloaded: 37000 bytes, type: audio/mp3
[stt] ffmpeg 8000Hz error: bun: command not found: ffmpeg
[stt] ffmpeg 16000Hz error: bun: command not found: ffmpeg
[recaptcha] transcription empty, refreshing audio
[solvers] attempted=[recaptcha-v2] solved=[]
```

The solver then loops over fresh audio challenges until `maxTimeout`, so reCAPTCHA v2 is effectively unsolvable in Docker.

## Fix

Add `ffmpeg` to the runtime stage's apt install list.

## Verification

Same image with `ffmpeg` installed, against https://www.google.com/recaptcha/api2/demo:

```
[recaptcha] switched to audio challenge
[stt] audio downloaded: 33238 bytes, type: audio/mp3
[stt] flac@8000Hz size: 82330 bytes
[recaptcha] solved via audio ✓
[solvers] attempted=[recaptcha-v2] solved=[recaptcha-v2]
```

Solved on the first attempt, ~32 s end to end.

## Note on image size

`ffmpeg` and its dependencies are not tiny, which cuts against the "lean runtime" goal of the stage. If that matters, a narrower alternative would be to drop the full package for a minimal static build, or make the STT path optional and document the requirement instead. Happy to rework this in whichever direction you prefer.