### PR TITLE
feat(scrape): optional viewport screenshot from the browser tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **DataDome support.** Detect Device Check, slider CAPTCHA and `t=bv` hard blocks from challenge markers and `x-dd-b`. Device Check uses a dedicated waiter and an optional headful Xvfb pool; the slider is reported as `datadome-captcha-required`. Enable startup-warmed capacity with `BROWSER_HEADFUL_POOL_SIZE=1` (off by default).
 - **AWS WAF Challenge support.** Detect the documented `202` Challenge and `405` CAPTCHA responses from their `x-amzn-waf-action` header, with a conservative two-marker HTML fallback. Silent challenges use a dedicated browser waiter for the domain-matching `aws-waf-token`; interactive CAPTCHA is surfaced as `aws-waf-captcha-required` for a future solver.
+- Optional viewport screenshot: `screenshot: true` on `POST /scrape` returns a base64 JPEG of the viewport in `ScrapeResult.screenshot`, captured by the browser tiers (2-4) immediately before the HTML read so image and markup describe the same moment. Off by default; a stock request attaches nothing and does no extra work. Settle wait, capture timeout, JPEG quality, and maximum image size are bounded and tunable via `SCREENSHOT_*`, and a capture failure leaves the field unset rather than failing the scrape.
 
 ### Fixed
 - Wait for the bundled Redis service to pass a `PING` healthcheck before starting TRAWL, preventing a transient Compose startup race from disabling the Tier 2 session cache for the process lifetime (#90).

--- a/apps/docs/api-reference/native-api.md
+++ b/apps/docs/api-reference/native-api.md
@@ -18,6 +18,7 @@ interface ScrapeRequest {
   sessionId?: string                     // sticky session override key
   headers?: Record<string, string>       // custom headers forwarded to the target
   proxy?: string                         // per-request proxy override for Tier 3/4
+  screenshot?: boolean                   // capture a viewport screenshot, default false
 }
 ```
 
@@ -32,6 +33,7 @@ interface ScrapeRequest {
 | `sessionId`  | string  | hostname | Override the Redis session key                                                                                                                                                                 |
 | `headers`    | object  | —        | Custom headers forwarded to the target across all tiers — see [Custom Headers](/api-reference/custom-headers)                                                                                  |
 | `proxy`      | string  | —        | Strict proxy route for this request. HTTP(S) proxies are used by Tier 1 and browser tiers; SOCKS proxies skip Tier 1. Direct Tier 1 and the unproxied Tier 2 cache are never used — see [Configuration § Proxies](/getting-started/configuration#proxies) |
+| `screenshot` | boolean | false    | Capture a base64 JPEG of the viewport on the browser tiers (2–4) and return it as `screenshot`. Tier 1 is a plain HTTP fetch and never produces one                                             |
 
 ## Response
 
@@ -48,6 +50,7 @@ interface ScrapeResult {
   totalMs: number
   captchasSolved?: string[]    // captcha types solved on the page itself (e.g. ['turnstile'])
   proxyUsed?: boolean          // true if the winning tier routed through a proxy (Tier 3 datacenter pool or Tier 4 residential pool/override)
+  screenshot?: string          // base64 JPEG of the viewport, only when requested and a browser tier served the page
 }
 
 interface TierResult {

--- a/apps/docs/getting-started/configuration.md
+++ b/apps/docs/getting-started/configuration.md
@@ -122,6 +122,20 @@ BROWSER_HEADFUL_POOL_SIZE=1   # required for DataDome targets, ~380 MB on first 
 
 These bounds keep an unresponsive Firefox process from permanently consuming a pool slot. The defaults are suitable for most installations.
 
+## Screenshots
+
+Only read when a request sets `screenshot: true` — see [Native API](/api-reference/native-api).
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `SCREENSHOT_SETTLE_MS` | `3000` | Maximum wait for the network to go idle before capturing |
+| `SCREENSHOT_TIMEOUT_MS` | `10000` | Maximum wait for the capture itself |
+| `SCREENSHOT_JPEG_QUALITY` | `60` | JPEG quality, 1–100 |
+| `SCREENSHOT_MAX_BYTES` | `4000000` | Images larger than this are dropped rather than returned |
+
+A screenshot is never worth failing a scrape: exceeding any of these bounds leaves
+`screenshot` unset and logs the reason, and the scrape result is otherwise unchanged.
+
 ## Session Cache
 
 ### `SESSION_TTL_SECONDS`

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -142,7 +142,16 @@ export async function scrape(
     if (session && maxTier >= 2) {
       const remaining = maxTimeout - (Date.now() - totalStart)
       const tier2Runner = runners.tier2 ?? runTier2
-      let t2 = await tier2Runner(req.url, handle, session, remaining, sanitizedHeaders, req.method, req.body)
+      let t2 = await tier2Runner(
+        req.url,
+        handle,
+        session,
+        remaining,
+        sanitizedHeaders,
+        req.method,
+        req.body,
+        req.screenshot,
+      )
       if (t2.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
         t2 = await tier2Runner(
@@ -153,6 +162,7 @@ export async function scrape(
           sanitizedHeaders,
           req.method,
           req.body,
+          req.screenshot,
         )
       }
       emit(t2)
@@ -179,6 +189,7 @@ export async function scrape(
           body: t2.body,
           responseHeaders: t2.responseHeaders,
           contentType: t2.contentType,
+          screenshot: t2.screenshot,
         }
       }
       // Session failed — purge it
@@ -199,7 +210,16 @@ export async function scrape(
     for (let attempt = 0; ; attempt++) {
       const remaining3 = maxTimeout - (Date.now() - totalStart)
       const tier3Runner = runners.tier3 ?? runTier3
-      t3 = await tier3Runner(req.url, handle, remaining3, proxy3, sanitizedHeaders, req.method, req.body)
+      t3 = await tier3Runner(
+        req.url,
+        handle,
+        remaining3,
+        proxy3,
+        sanitizedHeaders,
+        req.method,
+        req.body,
+        req.screenshot,
+      )
       if (t3.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
         t3 = await tier3Runner(
@@ -210,6 +230,7 @@ export async function scrape(
           sanitizedHeaders,
           req.method,
           req.body,
+          req.screenshot,
         )
       }
 
@@ -248,6 +269,7 @@ export async function scrape(
         body: t3.body,
         responseHeaders: t3.responseHeaders,
         contentType: t3.contentType,
+        screenshot: t3.screenshot,
       }
     }
 
@@ -270,7 +292,16 @@ export async function scrape(
     for (let attempt = 0; ; attempt++) {
       console.log(`[orchestrator] Tier 4 via residential proxy: ${proxy4.replace(/\/\/[^@]*@/, "//**@")}`)
       const remaining4 = maxTimeout - (Date.now() - totalStart)
-      t4 = await runTier4Lazy(req.url, handle, remaining4, proxy4, sanitizedHeaders, req.method, req.body)
+      t4 = await runTier4Lazy(
+        req.url,
+        handle,
+        remaining4,
+        proxy4,
+        sanitizedHeaders,
+        req.method,
+        req.body,
+        req.screenshot,
+      )
       if (t4.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
         t4 = await runTier4Lazy(
@@ -281,6 +312,7 @@ export async function scrape(
           sanitizedHeaders,
           req.method,
           req.body,
+          req.screenshot,
         )
       }
 
@@ -316,6 +348,7 @@ export async function scrape(
         body: t4.body,
         responseHeaders: t4.responseHeaders,
         contentType: t4.contentType,
+        screenshot: t4.screenshot,
       }
     }
 

--- a/packages/tiers/src/screenshot.ts
+++ b/packages/tiers/src/screenshot.ts
@@ -1,0 +1,32 @@
+import type { Page } from "patchright"
+
+// A screenshot is a best-effort side artifact of a scrape, so every step is bounded:
+// the settle wait, the capture itself, and the size of the image we are willing to
+// carry in the response. All are env-tunable.
+const SETTLE_MS = Number(process.env.SCREENSHOT_SETTLE_MS ?? 3_000)
+const CAPTURE_TIMEOUT_MS = Number(process.env.SCREENSHOT_TIMEOUT_MS ?? 10_000)
+const JPEG_QUALITY = Number(process.env.SCREENSHOT_JPEG_QUALITY ?? 60)
+const MAX_BYTES = Number(process.env.SCREENSHOT_MAX_BYTES ?? 4_000_000)
+
+// Viewport only — never fullPage. A challenge wall or an infinite-scroll page stitches
+// into a tall, mostly-empty canvas that costs seconds and shows less than the first
+// screen does.
+export async function capturePageScreenshot(page: Page): Promise<string | undefined> {
+  try {
+    // The HTML is read the moment a challenge clears, before late content (images,
+    // fonts, lazy hydration) has painted. Give the page a bounded chance to settle,
+    // then a short beat for whatever paints after the last request.
+    await page.waitForLoadState("networkidle", { timeout: SETTLE_MS }).catch(() => {})
+    await new Promise((r) => setTimeout(r, 300))
+
+    const image = await page.screenshot({ type: "jpeg", quality: JPEG_QUALITY, timeout: CAPTURE_TIMEOUT_MS })
+    if (image.length > MAX_BYTES) {
+      console.log(`[screenshot] dropped: ${image.length}b exceeds SCREENSHOT_MAX_BYTES=${MAX_BYTES}`)
+      return undefined
+    }
+    return Buffer.from(image).toString("base64")
+  } catch (err) {
+    console.log(`[screenshot] capture failed: ${err instanceof Error ? err.message : String(err)}`)
+    return undefined
+  }
+}

--- a/packages/tiers/src/tiers/2.ts
+++ b/packages/tiers/src/tiers/2.ts
@@ -1,5 +1,6 @@
 import type { BrowserHandle } from "@trawl/browser"
 import type { Cookie, SessionData, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { normalizeSameSite, toCookies } from "../utils/cookies"
 import {
@@ -26,6 +27,7 @@ export interface Tier2Result extends TierResult {
   cookies?: Cookie[]
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier2(
@@ -36,6 +38,7 @@ export async function runTier2(
   extraHeaders?: Record<string, string>,
   method?: string,
   body?: string,
+  screenshot?: boolean,
 ): Promise<Tier2Result> {
   const start = Date.now()
   const activeContext = handle.context
@@ -119,6 +122,10 @@ export async function runTier2(
       captchasSolved = result.solved
     }
 
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+
     const finalHtml = await page.content()
     if (isCloudflarePage(finalHtml, mainResponse.headers)) {
       return { tier: 2, status: "blocked", durationMs: Date.now() - start, reason: "session-expired" }
@@ -140,6 +147,7 @@ export async function runTier2(
       cookies,
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -1,6 +1,7 @@
 import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { routeChallengeWait } from "../utils/challengeRouter"
 import { snapshotChallengeCookies, toCookies } from "../utils/cookies"
@@ -49,6 +50,7 @@ export interface Tier3Result extends TierResult {
   userAgent?: string
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier3(
@@ -59,6 +61,7 @@ export async function runTier3(
   extraHeaders?: Record<string, string>,
   method?: string,
   body?: string,
+  screenshot?: boolean,
 ): Promise<Tier3Result> {
   const start = Date.now()
 
@@ -152,6 +155,10 @@ export async function runTier3(
       captchasSolved = solveResult.solved
     }
 
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+
     const html = await page.content()
 
     // Empty shell means the browser got nothing — treat as a load failure
@@ -233,6 +240,7 @@ export async function runTier3(
       userAgent: await page.evaluate(() => navigator.userAgent).catch(() => FINGERPRINT.userAgent),
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -1,6 +1,7 @@
 import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { routeChallengeWait } from "../utils/challengeRouter"
 import { snapshotChallengeCookies, toCookies } from "../utils/cookies"
@@ -33,6 +34,7 @@ export interface Tier4Result extends TierResult {
   userAgent?: string
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier4(
@@ -43,6 +45,7 @@ export async function runTier4(
   extraHeaders?: Record<string, string>,
   method?: string,
   body?: string,
+  screenshot?: boolean,
 ): Promise<Tier4Result> {
   const start = Date.now()
 
@@ -123,6 +126,10 @@ export async function runTier4(
       const solveResult = await solvePageCaptchas(page, solveRemaining).catch(() => ({ attempted: [], solved: [] }))
       captchasSolved = solveResult.solved
     }
+
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
 
     const html = await page.content()
 
@@ -205,6 +212,7 @@ export async function runTier4(
       userAgent: await page.evaluate(() => navigator.userAgent).catch(() => FINGERPRINT.userAgent),
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/tests/screenshot.test.ts
+++ b/packages/tiers/tests/screenshot.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test"
+import type { BrowserHandle } from "@trawl/browser"
+import type { SessionData } from "@trawl/types"
+import type { OrchestratorDeps } from "../src/orchestrator"
+import { scrape } from "../src/orchestrator"
+import { capturePageScreenshot } from "../src/screenshot"
+import { runTier2 } from "../src/tiers/2"
+import { runTier3 } from "../src/tiers/3"
+import { runTier4 } from "../src/tiers/4"
+
+const PAGE_HTML = `<html><head><title>Ordinary Page</title></head><body>${"content ".repeat(20)}</body></html>`
+const JPEG = Buffer.from("fake-jpeg-bytes")
+const JPEG_BASE64 = JPEG.toString("base64")
+
+const fingerprint = { userAgent: "test-agent", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" }
+
+const session: SessionData = { cookies: [], userAgent: "cached-user-agent", savedAt: 1 }
+
+interface PageStub {
+  screenshotCalls: Array<Record<string, unknown>>
+  page: any
+}
+
+const makePage = (options: { failScreenshot?: boolean } = {}): PageStub => {
+  const screenshotCalls: Array<Record<string, unknown>> = []
+  const page = {
+    url: () => "https://example.com/landed",
+    title: async () => "Ordinary Page",
+    content: async () => PAGE_HTML,
+    goto: async () => {},
+    on: () => {},
+    mainFrame: () => ({}),
+    frames: () => [],
+    context: () => ({ cookies: async () => [] }),
+    evaluate: async () => "test-agent",
+    setExtraHTTPHeaders: async () => {},
+    waitForLoadState: async () => {},
+    close: async () => {},
+    screenshot: async (opts: Record<string, unknown>) => {
+      screenshotCalls.push(opts)
+      if (options.failScreenshot) throw new Error("screenshot failed: target closed")
+      return JPEG
+    },
+  }
+  return { screenshotCalls, page }
+}
+
+const poolHandle = (page: unknown): BrowserHandle =>
+  ({
+    id: 1,
+    lease: 1,
+    context: { newPage: async () => page, addCookies: async () => {}, cookies: async () => [] },
+    browser: {},
+    fingerprint,
+  }) satisfies BrowserHandle
+
+const freshHandle = (page: unknown): BrowserHandle =>
+  ({
+    id: 2,
+    lease: 1,
+    context: {},
+    browser: {
+      newContext: async () => ({
+        newPage: async () => page,
+        addInitScript: async () => {},
+        cookies: async () => [],
+        close: async () => {},
+      }),
+    },
+    fingerprint,
+  }) satisfies BrowserHandle
+
+describe("capturePageScreenshot", () => {
+  test("returns base64 JPEG of the viewport, never a full-page capture", async () => {
+    const { page, screenshotCalls } = makePage()
+
+    expect(await capturePageScreenshot(page)).toBe(JPEG_BASE64)
+    expect(screenshotCalls).toHaveLength(1)
+    expect(screenshotCalls[0].type).toBe("jpeg")
+    expect(screenshotCalls[0].fullPage).toBeUndefined()
+    expect(screenshotCalls[0].timeout).toBeGreaterThan(0)
+  })
+
+  test("degrades to undefined when the page cannot be captured", async () => {
+    const { page } = makePage({ failScreenshot: true })
+
+    expect(await capturePageScreenshot(page)).toBeUndefined()
+  })
+})
+
+describe("browser tiers", () => {
+  test("Tier 2 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier2(
+      "https://example.com",
+      poolHandle(requested.page),
+      session,
+      4_000,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier2("https://example.com", poolHandle(untouched.page), session, 4_000)
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("Tier 3 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier3(
+      "https://example.com",
+      freshHandle(requested.page),
+      4_000,
+      undefined,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier3("https://example.com", freshHandle(untouched.page), 4_000)
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("Tier 4 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier4(
+      "https://example.com",
+      freshHandle(requested.page),
+      4_000,
+      "http://proxy.example:8080",
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier4(
+      "https://example.com",
+      freshHandle(untouched.page),
+      4_000,
+      "http://proxy.example:8080",
+    )
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("a failing screenshot still yields a successful scrape on every browser tier", async () => {
+    const t2 = await runTier2(
+      "https://example.com",
+      poolHandle(makePage({ failScreenshot: true }).page),
+      session,
+      4_000,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t2.status).toBe("success")
+    expect(t2.html).toContain("Ordinary Page")
+    expect(t2.screenshot).toBeUndefined()
+
+    const t3 = await runTier3(
+      "https://example.com",
+      freshHandle(makePage({ failScreenshot: true }).page),
+      4_000,
+      undefined,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t3.status).toBe("success")
+    expect(t3.screenshot).toBeUndefined()
+
+    const t4 = await runTier4(
+      "https://example.com",
+      freshHandle(makePage({ failScreenshot: true }).page),
+      4_000,
+      "http://proxy.example:8080",
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t4.status).toBe("success")
+    expect(t4.screenshot).toBeUndefined()
+  })
+})
+
+describe("orchestrator", () => {
+  const depsFor = (page: unknown): OrchestratorDeps => ({
+    acquireBrowser: async () => freshHandle(page),
+    releaseBrowser: () => {},
+    loadSession: async () => undefined,
+    saveSession: async () => {},
+    invalidateSession: async () => {},
+  })
+
+  test("emits the tier's screenshot on the scrape result when requested", async () => {
+    const { page } = makePage()
+
+    const result = await scrape(
+      { url: "https://example.com", skipHttp: true, maxTier: 3, maxTimeout: 4_000, screenshot: true },
+      depsFor(page),
+    )
+
+    expect(result.tier).toBe(3)
+    expect(result.screenshot).toBe(JPEG_BASE64)
+  })
+
+  test("omits the screenshot by default", async () => {
+    const { page, screenshotCalls } = makePage()
+
+    const result = await scrape(
+      { url: "https://example.com", skipHttp: true, maxTier: 3, maxTimeout: 4_000 },
+      depsFor(page),
+    )
+
+    expect(result.tier).toBe(3)
+    expect(result.screenshot).toBeUndefined()
+    expect(screenshotCalls).toHaveLength(0)
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,6 +27,10 @@ export interface ScrapeRequest {
   body?: string
   // Strict per-request route: target traffic must use this proxy and never fall back direct.
   proxy?: string
+  // Opt-in viewport screenshot from the browser tiers (2-4), returned as
+  // `ScrapeResult.screenshot`. Off by default — it costs a settle wait and payload
+  // size. Tier 1 is a plain HTTP fetch and never produces one.
+  screenshot?: boolean
 }
 
 export interface TierResult {
@@ -58,6 +62,9 @@ export interface ScrapeResult {
   responseHeaders?: Record<string, string>
   // Convenience: extracted Content-Type header. Same as responseHeaders['content-type'].
   contentType?: string
+  // Base64 JPEG of the viewport, present only when the request asked for it and a
+  // browser tier served the page. No `data:` prefix.
+  screenshot?: string
 }
 
 export interface SessionData {


### PR DESCRIPTION
## Summary

Adds an optional `screenshot: true` request flag. When set, the browser tiers (2–4) return a base64 JPEG of the viewport as `ScrapeResult.screenshot`. Off by default — with the flag unset, nothing is attached and no extra work is done, so a stock request behaves and costs exactly as it does today.

Anything running the browser tiers has already paid for a full render, and today that render is discarded — a caller that needs the rendered view has to fetch the same page a second time in its own browser. Typical uses: archiving what a page looked like at scrape time, diffing a page across runs, and confirming a challenge actually cleared rather than inferring it from markup that merely looks plausible.

## Linked issues

n/a — happy to convert this to a feature-request issue first if you would prefer that; the code is here to make the shape concrete rather than to pre-empt the discussion.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Design notes

Three decisions worth flagging, all reversible if you would rather they went the other way:

**Viewport, not `fullPage`.** A challenge wall or an infinite-scroll page stitches into a tall, mostly-empty canvas that costs seconds and shows less than the first screen does.

**JPEG, not PNG.** These are photographs of rendered pages, not diagrams; JPEG at quality 60 is roughly an order of magnitude smaller with no meaningful loss for this purpose. The quality is tunable.

**Captured before the HTML read**, so the image and the returned markup describe the same moment. The HTML is read as soon as a challenge clears, which is often before late content has painted, so the capture takes a bounded settle wait (`networkidle`, then a 300 ms beat) first.

Everything is bounded and env-tunable, and a failure is never fatal to the scrape — a capture that times out or exceeds the size cap logs and leaves the field unset rather than failing the request:

| Variable | Default | Purpose |
| --- | ---: | --- |
| `SCREENSHOT_SETTLE_MS` | `3000` | Bound on the `networkidle` settle wait |
| `SCREENSHOT_TIMEOUT_MS` | `10000` | Bound on the capture itself |
| `SCREENSHOT_JPEG_QUALITY` | `60` | JPEG quality |
| `SCREENSHOT_MAX_BYTES` | `4000000` | Oversize images are dropped, not truncated |

Tier 1 is a plain HTTP fetch and never produces a screenshot; that is documented rather than silently empty.

## Checklist

- [x] I ran `bun run check` and it passes locally
- [x] I added tests for the behavior change — `packages/tiers/tests/screenshot.test.ts`, 8 cases covering the happy path, the size cap, the capture timeout, and that a failure leaves the field unset without failing the scrape
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md

`bun run typecheck`, `bun run check` and `bun test` all pass on this branch (279 tests).

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under AGPL-3.0.

