### PR TITLE
fix(image): keep the spoofed OS font bundles behind a build arg

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -53,6 +53,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Pin the browser release and verify the architecture-specific asset before extracting it.
 # Direct downloads keep builds reproducible and avoid camoufox-js resolving "latest".
 ARG TARGETARCH
+# The pool spoofs a per-browser OS (packages/browser/src/pool.ts maps Win32 -> "windows",
+# MacIntel -> "macos"), and Camoufox spoofs that OS's font list with it. Dropping those
+# bundles therefore leaves a browser advertising fonts whose files are gone: every glyph
+# renders as a tofu box, and the fingerprint is self-inconsistent for anti-bot scoring.
+# Set KEEP_SPOOFED_OS_FONTS=1 to keep them (+891MB) when rendered output matters.
+ARG KEEP_SPOOFED_OS_FONTS=0
 RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     case "$TARGETARCH" in \
       amd64) ZIP="camoufox-152.0.4-beta.28-lin.x86_64.zip"; SHA256="924f3109ccd6d47cd6a0384d67a345fadf975d48b6319f8dbbd5954c588982bd" ;; \
@@ -67,7 +73,9 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     rm /tmp/camoufox.zip && \
     printf '{"version":"152.0.4","release":"beta.28"}\n' > /opt/camoufox/version.json && \
     chmod -R 755 /opt/camoufox && \
-    rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows
+    if [ "$KEEP_SPOOFED_OS_FONTS" != "1" ]; then \
+      rm -rf /opt/camoufox/fonts/macos /opt/camoufox/fonts/windows; \
+    fi
 
 # Bake the GeoIP database so camoufox-js never downloads it at runtime.
 # `geoip: true` (packages/browser/src/pool.ts) otherwise makes camoufox-js fetch


### PR DESCRIPTION
## Summary

Puts the macOS/Windows font-bundle deletion behind a `KEEP_SPOOFED_OS_FONTS` build arg. **Default is `0`, which is exactly today's behavior** — the bundles are still deleted, the image does not grow, and nobody who does not opt in sees any change.

## Linked issues

Closes #97.

## The problem

`FINGERPRINT_POOL` spoofs `Win32` and `MacIntel`, `pool.ts:213` maps those onto Camoufox's `windows`/`macos` OS tokens, and Camoufox spoofs the matching font list. The Dockerfile then deletes those bundles, so any browser not spoofing Linux advertises fonts whose files are gone. Every glyph renders as a tofu box, and the fingerprint is self-inconsistent in a way anti-bot vendors score on.

Because `FINGERPRINT_POOL` is indexed by browser number, browser 0 is always `Win32` and browser 1 always `MacIntel` — so this is the common case, not an edge one.

It cannot be caught from inside the container: the system Liberation fonts are installed and `fc-match` resolves normally. Only a rendered pixel shows it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Why a build arg rather than a straight revert

The deletion is there for a real reason — the bundles cost 1.24 GB → 2.72 GB. That is a big enough jump that defaulting it on would be a rude surprise for the FlareSolverr-replacement use case, where nobody looks at pixels and the fonts genuinely are dead weight. Opt-in keeps the small image the default and gives the option to anyone who renders pages or cares about platform/font consistency.

As noted in #97, I would equally happily send the narrower alternative: restrict `FINGERPRINT_POOL` to Linux when the bundles are absent, so the spoofed OS and the installed fonts can never disagree in the first place. That fixes the inconsistency without the size question. Say the word and I will swap this for it.

## Checklist

- [x] I opened an issue before this PR — #97
- [x] I ran `bun run check` and it passes locally
- [ ] Tests — n/a, this is a Dockerfile build-arg change with no runtime surface. Verified by building both ways and rendering the same URL: default build reproduces the tofu boxes, `--build-arg KEEP_SPOOFED_OS_FONTS=1` renders correctly.
- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md

`bun run typecheck`, `bun run check` and `bun test` pass on this branch (271 tests, unchanged from `dev`).

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under AGPL-3.0.
