### PR TITLE
fix(image): track the rolling GeoLite release instead of a pin that 404s

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -78,14 +78,19 @@ RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
 # Baking a verified copy into the image makes startup deterministic and removes the
 # runtime GitHub dependency + first-launch download latency. The size check fails the
 # build if the download is truncated, so a corrupt file can never be baked in.
-# P3TERX/GeoLite.mmdb keeps only the last few daily releases, so a pin more than a few days
-# old stops resolving and the build fails on a 404 here. Bump both values together.
-ARG GEOLITE_RELEASE=2026.08.25
-ARG GEOLITE_CITY_SHA256=b481e34bdfbeb937434d09b47d89622c36051560c5f64853b54e081678c7df74
+# P3TERX/GeoLite.mmdb retains only its two most recent releases, so a pinned tag 404s
+# within days and every build after that fails on curl exit 22 — which is what happened
+# to the 2026.08.07 and 2026.08.19 pins. Track the rolling latest and keep the guarantee
+# that actually matters here (a truncated file is never baked in) with a size floor; the
+# digest of a release that gets deleted cannot be kept current, and it was never a
+# provenance check on MaxMind's data anyway.
+ARG GEOLITE_CITY_MIN_BYTES=50000000
 RUN curl -fsSL \
-      "https://github.com/P3TERX/GeoLite.mmdb/releases/download/${GEOLITE_RELEASE}/GeoLite2-City.mmdb" \
+      "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-City.mmdb" \
       -o /opt/camoufox/GeoLite2-City.mmdb && \
-    echo "${GEOLITE_CITY_SHA256}  /opt/camoufox/GeoLite2-City.mmdb" | sha256sum --check --strict -
+    actual=$(stat -c%s /opt/camoufox/GeoLite2-City.mmdb) && \
+    [ "$actual" -ge "${GEOLITE_CITY_MIN_BYTES}" ] || \
+      { echo "GeoLite2-City.mmdb is $actual bytes, below ${GEOLITE_CITY_MIN_BYTES}" >&2; exit 1; }
 
 # Bake uBlock Origin into Camoufox's expected addon directory. camoufox-js still
 # performs its normal addon registration at startup, but no runtime download or


### PR DESCRIPTION
## Summary

Tracks `releases/latest` for the GeoLite City database instead of a dated tag, and replaces the SHA-256 check with a minimum-size check. The build stops breaking every couple of weeks.

## Linked issues

Closes #98.

## The problem

`P3TERX/GeoLite.mmdb` retains only its most recent releases, so a dated pin 404s within days and every build after that fails on `curl` exit 22. The pin has already been bumped three times in fifteen days (`ff5756c` 2026-08-10, `d109dff` 2026-08-21, `3ebbbc5` 2026-08-25, the last of those filed as #87), and the current one will age out the same way. Between expiry and the next bump, nobody downstream can build the image.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## On dropping the digest

This is the part worth arguing about, so to be explicit about what is and is not lost.

The digest looks like a supply-chain control, but it pins an artifact that is deleted upstream on a rolling schedule — so it can never be kept current, and each bump replaces it with a digest of whatever is newest, which is not a verification so much as a record of what was downloaded that day. It was also never a provenance check on MaxMind's data, only on one mirror's daily snapshot.

What the digest *does* reliably deliver is that a truncated or corrupt download never gets baked into the image. This PR keeps that guarantee with a size floor:

```dockerfile
ARG GEOLITE_CITY_MIN_BYTES=50000000
```

A truncated file still fails the build loudly, with a message naming the actual size. The floor is a build arg, so anyone who wants to raise it — or pin a specific release again — can do so without patching the Dockerfile.

If you would rather keep a cryptographic pin, the durable version is to vendor or mirror the `.mmdb` somewhere that does not delete it, and I would be glad to send that instead. I do not think the status quo is a third option, though: it is a recurring maintenance interrupt for you and a broken build for everyone downstream in between.

## Checklist

- [x] I opened an issue before this PR — #98
- [x] I ran `bun run check` and it passes locally
- [ ] Tests — n/a, Dockerfile-only change with no runtime surface. Verified by building the image and confirming the baked `.mmdb` is present and correctly sized, and that an artificially truncated download fails the layer.
- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md

`bun run typecheck`, `bun run check` and `bun test` pass on this branch (271 tests, unchanged from `dev`).

## AGPL notice

By submitting this PR, I confirm my contribution is my own work and I agree to license it under AGPL-3.0.
