### PR TITLE
feat(scrape): safely add optional viewport screenshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ BROWSER_LAUNCH_TIMEOUT_MS=90000
 # Optional Chrome executable override.
 CHROME_EXECUTABLE=
 
+# Optional viewport screenshots (browser tiers only)
+SCREENSHOT_SETTLE_MS=3000
+SCREENSHOT_TIMEOUT_MS=10000
+SCREENSHOT_JPEG_QUALITY=60
+SCREENSHOT_MAX_BYTES=4000000
+
 # Sessions
 # Redis stores solved cookies and browser sessions.
 REDIS_URL=redis://localhost:6379

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **DataDome support.** Detect Device Check, slider CAPTCHA and `t=bv` hard blocks from challenge markers and `x-dd-b`. Device Check uses a dedicated waiter and an optional headful Xvfb pool; the slider is reported as `datadome-captcha-required`. Enable startup-warmed capacity with `BROWSER_HEADFUL_POOL_SIZE=1` (off by default).
 - **AWS WAF Challenge support.** Detect the documented `202` Challenge and `405` CAPTCHA responses from their `x-amzn-waf-action` header, with a conservative two-marker HTML fallback. Silent challenges use a dedicated browser waiter for the domain-matching `aws-waf-token`; interactive CAPTCHA is surfaced as `aws-waf-captcha-required` for a future solver.
+- Optional viewport screenshot: `screenshot: true` on `POST /scrape` returns a base64 JPEG of the viewport in `ScrapeResult.screenshot`, captured by the browser tiers (2-4) immediately before the HTML read so image and markup describe the same moment. Off by default; a stock request attaches nothing and does no extra work. Settle wait, capture timeout, JPEG quality, and maximum image size are bounded and tunable via `SCREENSHOT_*`, and a capture failure leaves the field unset rather than failing the scrape.
 
 ### Fixed
 - Wait for the bundled Redis service to pass a `PING` healthcheck before starting TRAWL, preventing a transient Compose startup race from disabling the Tier 2 session cache for the process lifetime (#90).

--- a/apps/api/src/validation.test.ts
+++ b/apps/api/src/validation.test.ts
@@ -32,6 +32,14 @@ describe("API request validation", () => {
     expect(() => validateScrapeRequest({ method: "GET", url: "https://example.com" })).not.toThrow()
   })
 
+  test("accepts boolean screenshot flags and rejects other values", () => {
+    expect(() => validateScrapeRequest({ url: "https://example.com", screenshot: true })).not.toThrow()
+    expect(() => validateScrapeRequest({ url: "https://example.com", screenshot: false })).not.toThrow()
+    expect(() => validateScrapeRequest({ url: "https://example.com", screenshot: "true" })).toThrow(
+      new RequestValidationError("screenshot must be a boolean", 400),
+    )
+  })
+
   test("extracts only string URLs for error envelopes", () => {
     expect(requestUrl({ url: "https://example.com" })).toBe("https://example.com")
     expect(requestUrl({ url: 42 })).toBe("")

--- a/apps/api/src/validation.ts
+++ b/apps/api/src/validation.ts
@@ -42,5 +42,8 @@ export function validateScrapeRequest(body: unknown): asserts body is ScrapeRequ
       400,
     )
   }
+  if (req.screenshot !== undefined && typeof req.screenshot !== "boolean") {
+    throw new RequestValidationError("screenshot must be a boolean", 400)
+  }
   requireContentTypeForBody(sanitizeHeaders(req.headers), Boolean(req.body))
 }

--- a/apps/docs/api-reference/native-api.md
+++ b/apps/docs/api-reference/native-api.md
@@ -18,6 +18,7 @@ interface ScrapeRequest {
   sessionId?: string                     // sticky session override key
   headers?: Record<string, string>       // custom headers forwarded to the target
   proxy?: string                         // per-request proxy override for Tier 3/4
+  screenshot?: boolean                   // capture a viewport screenshot, default false
 }
 ```
 
@@ -32,6 +33,7 @@ interface ScrapeRequest {
 | `sessionId`  | string  | hostname | Override the Redis session key                                                                                                                                                                 |
 | `headers`    | object  | —        | Custom headers forwarded to the target across all tiers — see [Custom Headers](/api-reference/custom-headers)                                                                                  |
 | `proxy`      | string  | —        | Strict proxy route for this request. HTTP(S) proxies are used by Tier 1 and browser tiers; SOCKS proxies skip Tier 1. Direct Tier 1 and the unproxied Tier 2 cache are never used — see [Configuration § Proxies](/getting-started/configuration#proxies) |
+| `screenshot` | boolean | false    | Capture a base64 JPEG of the viewport on the browser tiers (2–4) and return it as `screenshot`. Tier 1 is a plain HTTP fetch and never produces one                                             |
 
 ## Response
 
@@ -48,6 +50,7 @@ interface ScrapeResult {
   totalMs: number
   captchasSolved?: string[]    // captcha types solved on the page itself (e.g. ['turnstile'])
   proxyUsed?: boolean          // true if the winning tier routed through a proxy (Tier 3 datacenter pool or Tier 4 residential pool/override)
+  screenshot?: string          // base64 JPEG of the viewport, only when requested and a browser tier served the page
 }
 
 interface TierResult {

--- a/apps/docs/api-reference/native-api.md
+++ b/apps/docs/api-reference/native-api.md
@@ -33,7 +33,7 @@ interface ScrapeRequest {
 | `sessionId`  | string  | hostname | Override the Redis session key                                                                                                                                                                 |
 | `headers`    | object  | —        | Custom headers forwarded to the target across all tiers — see [Custom Headers](/api-reference/custom-headers)                                                                                  |
 | `proxy`      | string  | —        | Strict proxy route for this request. HTTP(S) proxies are used by Tier 1 and browser tiers; SOCKS proxies skip Tier 1. Direct Tier 1 and the unproxied Tier 2 cache are never used — see [Configuration § Proxies](/getting-started/configuration#proxies) |
-| `screenshot` | boolean | false    | Capture a base64 JPEG of the viewport on the browser tiers (2–4) and return it as `screenshot`. Tier 1 is a plain HTTP fetch and never produces one                                             |
+| `screenshot` | boolean | false    | Capture a base64 JPEG of the viewport on browser tiers (2–4) and return it as `screenshot`. Tier 1 never produces one; use `skipHttp: true` to force a browser attempt                        |
 
 ## Response
 

--- a/apps/docs/getting-started/configuration.md
+++ b/apps/docs/getting-started/configuration.md
@@ -148,6 +148,20 @@ BROWSER_HEADFUL_POOL_SIZE=1   # required for DataDome targets, ~380 MB on first 
 
 These bounds keep an unresponsive Firefox process from permanently consuming a pool slot. The defaults are suitable for most installations.
 
+## Screenshots
+
+Only read when a request sets `screenshot: true` — see [Native API](/api-reference/native-api).
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `SCREENSHOT_SETTLE_MS` | `3000` | Maximum wait for the network to go idle before capturing |
+| `SCREENSHOT_TIMEOUT_MS` | `10000` | Maximum wait for the capture itself |
+| `SCREENSHOT_JPEG_QUALITY` | `60` | JPEG quality, 1–100 |
+| `SCREENSHOT_MAX_BYTES` | `4000000` | Images larger than this are dropped rather than returned |
+
+A screenshot is never worth failing a scrape: exceeding any of these bounds leaves
+`screenshot` unset and logs the reason, and the scrape result is otherwise unchanged.
+
 ## Session Cache
 
 ### `SESSION_TTL_SECONDS`

--- a/apps/docs/getting-started/configuration.md
+++ b/apps/docs/getting-started/configuration.md
@@ -161,6 +161,8 @@ Only read when a request sets `screenshot: true` — see [Native API](/api-refer
 
 A screenshot is never worth failing a scrape: exceeding any of these bounds leaves
 `screenshot` unset and logs the reason, and the scrape result is otherwise unchanged.
+Tier 1 is a plain HTTP fetch and never captures a screenshot. Set `skipHttp: true` if
+you need to force a browser-tier attempt.
 
 ## Session Cache
 

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -79,8 +79,8 @@ export async function scrape(
   const sanitizedHeaders = sanitizeHeaders(req.headers)
   requireContentTypeForBody(sanitizedHeaders, Boolean(req.body))
 
-  const emit = (r: TierResult & { challenge?: unknown }) => {
-    const { challenge: _challenge, ...publicResult } = r
+  const emit = (r: TierResult & { challenge?: unknown; screenshot?: string }) => {
+    const { challenge: _challenge, screenshot: _screenshot, ...publicResult } = r
     timings.push(publicResult)
     deps.onTierAttempt?.(publicResult)
   }

--- a/packages/tiers/src/orchestrator.ts
+++ b/packages/tiers/src/orchestrator.ts
@@ -152,6 +152,7 @@ export async function scrape(
         req.method,
         req.body,
         deps.validateOutboundUrl,
+        req.screenshot,
       )
       if (t2.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
@@ -164,6 +165,7 @@ export async function scrape(
           req.method,
           req.body,
           deps.validateOutboundUrl,
+          req.screenshot,
         )
       }
       emit(t2)
@@ -190,6 +192,7 @@ export async function scrape(
           body: t2.body,
           responseHeaders: t2.responseHeaders,
           contentType: t2.contentType,
+          screenshot: t2.screenshot,
         }
       }
       // Session failed — purge it
@@ -219,6 +222,7 @@ export async function scrape(
         req.method,
         req.body,
         deps.validateOutboundUrl,
+        req.screenshot,
       )
       if (t3.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
@@ -231,6 +235,7 @@ export async function scrape(
           req.method,
           req.body,
           deps.validateOutboundUrl,
+          req.screenshot,
         )
       }
 
@@ -269,6 +274,7 @@ export async function scrape(
         body: t3.body,
         responseHeaders: t3.responseHeaders,
         contentType: t3.contentType,
+        screenshot: t3.screenshot,
       }
     }
 
@@ -300,6 +306,7 @@ export async function scrape(
         req.method,
         req.body,
         deps.validateOutboundUrl,
+        req.screenshot,
       )
       if (t4.challenge === "datadome" && !handle.headful) {
         await switchToHeadful()
@@ -312,6 +319,7 @@ export async function scrape(
           req.method,
           req.body,
           deps.validateOutboundUrl,
+          req.screenshot,
         )
       }
 
@@ -347,6 +355,7 @@ export async function scrape(
         body: t4.body,
         responseHeaders: t4.responseHeaders,
         contentType: t4.contentType,
+        screenshot: t4.screenshot,
       }
     }
 

--- a/packages/tiers/src/screenshot.ts
+++ b/packages/tiers/src/screenshot.ts
@@ -1,0 +1,32 @@
+import type { Page } from "patchright"
+
+// A screenshot is a best-effort side artifact of a scrape, so every step is bounded:
+// the settle wait, the capture itself, and the size of the image we are willing to
+// carry in the response. All are env-tunable.
+const SETTLE_MS = Number(process.env.SCREENSHOT_SETTLE_MS ?? 3_000)
+const CAPTURE_TIMEOUT_MS = Number(process.env.SCREENSHOT_TIMEOUT_MS ?? 10_000)
+const JPEG_QUALITY = Number(process.env.SCREENSHOT_JPEG_QUALITY ?? 60)
+const MAX_BYTES = Number(process.env.SCREENSHOT_MAX_BYTES ?? 4_000_000)
+
+// Viewport only — never fullPage. A challenge wall or an infinite-scroll page stitches
+// into a tall, mostly-empty canvas that costs seconds and shows less than the first
+// screen does.
+export async function capturePageScreenshot(page: Page): Promise<string | undefined> {
+  try {
+    // The HTML is read the moment a challenge clears, before late content (images,
+    // fonts, lazy hydration) has painted. Give the page a bounded chance to settle,
+    // then a short beat for whatever paints after the last request.
+    await page.waitForLoadState("networkidle", { timeout: SETTLE_MS }).catch(() => {})
+    await new Promise((r) => setTimeout(r, 300))
+
+    const image = await page.screenshot({ type: "jpeg", quality: JPEG_QUALITY, timeout: CAPTURE_TIMEOUT_MS })
+    if (image.length > MAX_BYTES) {
+      console.log(`[screenshot] dropped: ${image.length}b exceeds SCREENSHOT_MAX_BYTES=${MAX_BYTES}`)
+      return undefined
+    }
+    return Buffer.from(image).toString("base64")
+  } catch (err) {
+    console.log(`[screenshot] capture failed: ${err instanceof Error ? err.message : String(err)}`)
+    return undefined
+  }
+}

--- a/packages/tiers/src/screenshot.ts
+++ b/packages/tiers/src/screenshot.ts
@@ -11,15 +11,26 @@ const MAX_BYTES = Number(process.env.SCREENSHOT_MAX_BYTES ?? 4_000_000)
 // Viewport only — never fullPage. A challenge wall or an infinite-scroll page stitches
 // into a tall, mostly-empty canvas that costs seconds and shows less than the first
 // screen does.
-export async function capturePageScreenshot(page: Page): Promise<string | undefined> {
+export async function capturePageScreenshot(
+  page: Page,
+  budgetMs = Number.POSITIVE_INFINITY,
+): Promise<string | undefined> {
+  const deadline = Date.now() + Math.max(budgetMs, 0)
+  const remaining = (): number => Math.max(deadline - Date.now(), 0)
+
   try {
     // The HTML is read the moment a challenge clears, before late content (images,
     // fonts, lazy hydration) has painted. Give the page a bounded chance to settle,
     // then a short beat for whatever paints after the last request.
-    await page.waitForLoadState("networkidle", { timeout: SETTLE_MS }).catch(() => {})
-    await new Promise((r) => setTimeout(r, 300))
+    if (remaining() <= 0) return undefined
+    await page.waitForLoadState("networkidle", { timeout: Math.min(SETTLE_MS, remaining()) }).catch(() => {})
+    const paintWaitMs = Math.min(300, remaining())
+    if (paintWaitMs > 0) await new Promise((r) => setTimeout(r, paintWaitMs))
 
-    const image = await page.screenshot({ type: "jpeg", quality: JPEG_QUALITY, timeout: CAPTURE_TIMEOUT_MS })
+    const captureTimeout = Math.min(CAPTURE_TIMEOUT_MS, remaining())
+    if (captureTimeout <= 0) return undefined
+
+    const image = await page.screenshot({ type: "jpeg", quality: JPEG_QUALITY, timeout: captureTimeout })
     if (image.length > MAX_BYTES) {
       console.log(`[screenshot] dropped: ${image.length}b exceeds SCREENSHOT_MAX_BYTES=${MAX_BYTES}`)
       return undefined

--- a/packages/tiers/src/tiers/2.ts
+++ b/packages/tiers/src/tiers/2.ts
@@ -1,5 +1,6 @@
 import type { BrowserHandle } from "@trawl/browser"
 import type { Cookie, SessionData, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { normalizeSameSite, toCookies } from "../utils/cookies"
 import {
@@ -27,6 +28,7 @@ export interface Tier2Result extends TierResult {
   cookies?: Cookie[]
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier2(
@@ -38,6 +40,7 @@ export async function runTier2(
   method?: string,
   body?: string,
   validateOutboundUrl?: OutboundUrlValidator,
+  screenshot?: boolean,
 ): Promise<Tier2Result> {
   const start = Date.now()
   const activeContext = handle.context
@@ -122,6 +125,10 @@ export async function runTier2(
       captchasSolved = result.solved
     }
 
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+
     const finalHtml = await page.content()
     if (isCloudflarePage(finalHtml, mainResponse.headers)) {
       return { tier: 2, status: "blocked", durationMs: Date.now() - start, reason: "session-expired" }
@@ -143,6 +150,7 @@ export async function runTier2(
       cookies,
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/src/tiers/2.ts
+++ b/packages/tiers/src/tiers/2.ts
@@ -127,7 +127,7 @@ export async function runTier2(
 
     // Shot before the html read so the image and the returned html describe the same
     // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
-    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+    const shot = screenshot ? await capturePageScreenshot(page, maxTimeout - (Date.now() - start)) : undefined
 
     const finalHtml = await page.content()
     if (isCloudflarePage(finalHtml, mainResponse.headers)) {

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -1,6 +1,7 @@
 import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { routeChallengeWait } from "../utils/challengeRouter"
 import { snapshotChallengeCookies, toCookies } from "../utils/cookies"
@@ -50,6 +51,7 @@ export interface Tier3Result extends TierResult {
   userAgent?: string
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier3(
@@ -61,6 +63,7 @@ export async function runTier3(
   method?: string,
   body?: string,
   validateOutboundUrl?: OutboundUrlValidator,
+  screenshot?: boolean,
 ): Promise<Tier3Result> {
   const start = Date.now()
 
@@ -155,6 +158,10 @@ export async function runTier3(
       captchasSolved = solveResult.solved
     }
 
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+
     const html = await page.content()
 
     // Empty shell means the browser got nothing — treat as a load failure
@@ -236,6 +243,7 @@ export async function runTier3(
       userAgent: await page.evaluate(() => navigator.userAgent).catch(() => FINGERPRINT.userAgent),
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/src/tiers/3.ts
+++ b/packages/tiers/src/tiers/3.ts
@@ -160,7 +160,7 @@ export async function runTier3(
 
     // Shot before the html read so the image and the returned html describe the same
     // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
-    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+    const shot = screenshot ? await capturePageScreenshot(page, maxTimeout - (Date.now() - start)) : undefined
 
     const html = await page.content()
 

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -1,6 +1,7 @@
 import type { BrowserHandle } from "@trawl/browser"
 import { closeTemporaryContext, FINGERPRINT, newFreshContext } from "@trawl/browser"
 import type { Cookie, TierResult } from "@trawl/types"
+import { capturePageScreenshot } from "../screenshot"
 import { solvePageCaptchas } from "../solvers"
 import { routeChallengeWait } from "../utils/challengeRouter"
 import { snapshotChallengeCookies, toCookies } from "../utils/cookies"
@@ -34,6 +35,7 @@ export interface Tier4Result extends TierResult {
   userAgent?: string
   statusCode?: number
   captchasSolved?: string[]
+  screenshot?: string
 }
 
 export async function runTier4(
@@ -45,6 +47,7 @@ export async function runTier4(
   method?: string,
   body?: string,
   validateOutboundUrl?: OutboundUrlValidator,
+  screenshot?: boolean,
 ): Promise<Tier4Result> {
   const start = Date.now()
 
@@ -127,6 +130,10 @@ export async function runTier4(
       captchasSolved = solveResult.solved
     }
 
+    // Shot before the html read so the image and the returned html describe the same
+    // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
+    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+
     const html = await page.content()
 
     if (html.length < 100) {
@@ -208,6 +215,7 @@ export async function runTier4(
       userAgent: await page.evaluate(() => navigator.userAgent).catch(() => FINGERPRINT.userAgent),
       statusCode: mainResponse.status,
       captchasSolved: captchasSolved.length > 0 ? captchasSolved : undefined,
+      screenshot: shot,
     }
   } catch (err) {
     return {

--- a/packages/tiers/src/tiers/4.ts
+++ b/packages/tiers/src/tiers/4.ts
@@ -132,7 +132,7 @@ export async function runTier4(
 
     // Shot before the html read so the image and the returned html describe the same
     // moment — the settle wait inside the capture can outlast a slow-clearing challenge.
-    const shot = screenshot ? await capturePageScreenshot(page) : undefined
+    const shot = screenshot ? await capturePageScreenshot(page, maxTimeout - (Date.now() - start)) : undefined
 
     const html = await page.content()
 

--- a/packages/tiers/tests/screenshot.test.ts
+++ b/packages/tiers/tests/screenshot.test.ts
@@ -18,11 +18,13 @@ const session: SessionData = { cookies: [], userAgent: "cached-user-agent", save
 
 interface PageStub {
   screenshotCalls: Array<Record<string, unknown>>
+  routePatterns: string[]
   page: any
 }
 
-const makePage = (options: { failScreenshot?: boolean } = {}): PageStub => {
+const makePage = (options: { failScreenshot?: boolean; image?: Buffer } = {}): PageStub => {
   const screenshotCalls: Array<Record<string, unknown>> = []
+  const routePatterns: string[] = []
   const page = {
     url: () => "https://example.com/landed",
     title: async () => "Ordinary Page",
@@ -34,20 +36,24 @@ const makePage = (options: { failScreenshot?: boolean } = {}): PageStub => {
     context: () => ({ cookies: async () => [] }),
     evaluate: async () => "test-agent",
     setExtraHTTPHeaders: async () => {},
+    route: async (pattern: string) => {
+      routePatterns.push(pattern)
+    },
     waitForLoadState: async () => {},
     close: async () => {},
     screenshot: async (opts: Record<string, unknown>) => {
       screenshotCalls.push(opts)
       if (options.failScreenshot) throw new Error("screenshot failed: target closed")
-      return JPEG
+      return options.image ?? JPEG
     },
   }
-  return { screenshotCalls, page }
+  return { screenshotCalls, routePatterns, page }
 }
 
 const poolHandle = (page: unknown): BrowserHandle =>
   ({
     id: 1,
+    headful: false,
     lease: 1,
     context: { newPage: async () => page, addCookies: async () => {}, cookies: async () => [] },
     browser: {},
@@ -57,6 +63,7 @@ const poolHandle = (page: unknown): BrowserHandle =>
 const freshHandle = (page: unknown): BrowserHandle =>
   ({
     id: 2,
+    headful: false,
     lease: 1,
     context: {},
     browser: {
@@ -86,6 +93,19 @@ describe("capturePageScreenshot", () => {
 
     expect(await capturePageScreenshot(page)).toBeUndefined()
   })
+
+  test("drops screenshots that exceed the 4 MB limit", async () => {
+    const { page } = makePage({ image: Buffer.alloc(4_000_001) })
+
+    expect(await capturePageScreenshot(page)).toBeUndefined()
+  })
+
+  test("does no capture work when the request budget is exhausted", async () => {
+    const { page, screenshotCalls } = makePage()
+
+    expect(await capturePageScreenshot(page, 0)).toBeUndefined()
+    expect(screenshotCalls).toHaveLength(0)
+  })
 })
 
 describe("browser tiers", () => {
@@ -99,6 +119,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(withShot.status).toBe("success")
@@ -121,6 +142,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(withShot.status).toBe("success")
@@ -143,6 +165,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(withShot.status).toBe("success")
@@ -169,6 +192,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(t2.status).toBe("success")
@@ -183,6 +207,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(t3.status).toBe("success")
@@ -196,6 +221,7 @@ describe("browser tiers", () => {
       {},
       "GET",
       "",
+      undefined,
       true,
     )
     expect(t4.status).toBe("success")
@@ -212,6 +238,32 @@ describe("orchestrator", () => {
     invalidateSession: async () => {},
   })
 
+  test("allows Tier 1 to succeed without producing or forcing a screenshot", async () => {
+    const originalFetch = globalThis.fetch
+    let browserAcquired = false
+    globalThis.fetch = (async () =>
+      new Response(PAGE_HTML, { status: 200, headers: { "content-type": "text/html" } })) as typeof fetch
+
+    try {
+      const result = await scrape(
+        { url: "https://example.com", screenshot: true },
+        {
+          ...depsFor(makePage().page),
+          acquireBrowser: async () => {
+            browserAcquired = true
+            return freshHandle(makePage().page)
+          },
+        },
+      )
+
+      expect(result.tier).toBe(1)
+      expect(result.screenshot).toBeUndefined()
+      expect(browserAcquired).toBeFalse()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   test("emits the tier's screenshot on the scrape result when requested", async () => {
     const { page } = makePage()
 
@@ -222,6 +274,20 @@ describe("orchestrator", () => {
 
     expect(result.tier).toBe(3)
     expect(result.screenshot).toBe(JPEG_BASE64)
+    expect(result.timings.every((timing) => !("screenshot" in timing))).toBeTrue()
+  })
+
+  test("keeps the outbound policy installed when screenshots are requested", async () => {
+    const { page, routePatterns } = makePage()
+    const validateOutboundUrl = async () => {}
+
+    const result = await scrape(
+      { url: "https://example.com", skipHttp: true, maxTier: 3, maxTimeout: 4_000, screenshot: true },
+      { ...depsFor(page), validateOutboundUrl },
+    )
+
+    expect(result.screenshot).toBe(JPEG_BASE64)
+    expect(routePatterns).toContain("**/*")
   })
 
   test("omits the screenshot by default", async () => {

--- a/packages/tiers/tests/screenshot.test.ts
+++ b/packages/tiers/tests/screenshot.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test"
+import type { BrowserHandle } from "@trawl/browser"
+import type { SessionData } from "@trawl/types"
+import type { OrchestratorDeps } from "../src/orchestrator"
+import { scrape } from "../src/orchestrator"
+import { capturePageScreenshot } from "../src/screenshot"
+import { runTier2 } from "../src/tiers/2"
+import { runTier3 } from "../src/tiers/3"
+import { runTier4 } from "../src/tiers/4"
+
+const PAGE_HTML = `<html><head><title>Ordinary Page</title></head><body>${"content ".repeat(20)}</body></html>`
+const JPEG = Buffer.from("fake-jpeg-bytes")
+const JPEG_BASE64 = JPEG.toString("base64")
+
+const fingerprint = { userAgent: "test-agent", platform: "Linux x86_64", locale: "en-US", timezone: "UTC" }
+
+const session: SessionData = { cookies: [], userAgent: "cached-user-agent", savedAt: 1 }
+
+interface PageStub {
+  screenshotCalls: Array<Record<string, unknown>>
+  page: any
+}
+
+const makePage = (options: { failScreenshot?: boolean } = {}): PageStub => {
+  const screenshotCalls: Array<Record<string, unknown>> = []
+  const page = {
+    url: () => "https://example.com/landed",
+    title: async () => "Ordinary Page",
+    content: async () => PAGE_HTML,
+    goto: async () => {},
+    on: () => {},
+    mainFrame: () => ({}),
+    frames: () => [],
+    context: () => ({ cookies: async () => [] }),
+    evaluate: async () => "test-agent",
+    setExtraHTTPHeaders: async () => {},
+    waitForLoadState: async () => {},
+    close: async () => {},
+    screenshot: async (opts: Record<string, unknown>) => {
+      screenshotCalls.push(opts)
+      if (options.failScreenshot) throw new Error("screenshot failed: target closed")
+      return JPEG
+    },
+  }
+  return { screenshotCalls, page }
+}
+
+const poolHandle = (page: unknown): BrowserHandle =>
+  ({
+    id: 1,
+    lease: 1,
+    context: { newPage: async () => page, addCookies: async () => {}, cookies: async () => [] },
+    browser: {},
+    fingerprint,
+  }) satisfies BrowserHandle
+
+const freshHandle = (page: unknown): BrowserHandle =>
+  ({
+    id: 2,
+    lease: 1,
+    context: {},
+    browser: {
+      newContext: async () => ({
+        newPage: async () => page,
+        addInitScript: async () => {},
+        cookies: async () => [],
+        close: async () => {},
+      }),
+    },
+    fingerprint,
+  }) satisfies BrowserHandle
+
+describe("capturePageScreenshot", () => {
+  test("returns base64 JPEG of the viewport, never a full-page capture", async () => {
+    const { page, screenshotCalls } = makePage()
+
+    expect(await capturePageScreenshot(page)).toBe(JPEG_BASE64)
+    expect(screenshotCalls).toHaveLength(1)
+    expect(screenshotCalls[0].type).toBe("jpeg")
+    expect(screenshotCalls[0].fullPage).toBeUndefined()
+    expect(screenshotCalls[0].timeout).toBeGreaterThan(0)
+  })
+
+  test("degrades to undefined when the page cannot be captured", async () => {
+    const { page } = makePage({ failScreenshot: true })
+
+    expect(await capturePageScreenshot(page)).toBeUndefined()
+  })
+})
+
+describe("browser tiers", () => {
+  test("Tier 2 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier2(
+      "https://example.com",
+      poolHandle(requested.page),
+      session,
+      4_000,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier2("https://example.com", poolHandle(untouched.page), session, 4_000)
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("Tier 3 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier3(
+      "https://example.com",
+      freshHandle(requested.page),
+      4_000,
+      undefined,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier3("https://example.com", freshHandle(untouched.page), 4_000)
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("Tier 4 returns a screenshot only when the request asks for one", async () => {
+    const requested = makePage()
+    const withShot = await runTier4(
+      "https://example.com",
+      freshHandle(requested.page),
+      4_000,
+      "http://proxy.example:8080",
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(withShot.status).toBe("success")
+    expect(withShot.screenshot).toBe(JPEG_BASE64)
+
+    const untouched = makePage()
+    const withoutShot = await runTier4(
+      "https://example.com",
+      freshHandle(untouched.page),
+      4_000,
+      "http://proxy.example:8080",
+    )
+    expect(withoutShot.status).toBe("success")
+    expect(withoutShot.screenshot).toBeUndefined()
+    expect(untouched.screenshotCalls).toHaveLength(0)
+  })
+
+  test("a failing screenshot still yields a successful scrape on every browser tier", async () => {
+    const t2 = await runTier2(
+      "https://example.com",
+      poolHandle(makePage({ failScreenshot: true }).page),
+      session,
+      4_000,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t2.status).toBe("success")
+    expect(t2.html).toContain("Ordinary Page")
+    expect(t2.screenshot).toBeUndefined()
+
+    const t3 = await runTier3(
+      "https://example.com",
+      freshHandle(makePage({ failScreenshot: true }).page),
+      4_000,
+      undefined,
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t3.status).toBe("success")
+    expect(t3.screenshot).toBeUndefined()
+
+    const t4 = await runTier4(
+      "https://example.com",
+      freshHandle(makePage({ failScreenshot: true }).page),
+      4_000,
+      "http://proxy.example:8080",
+      {},
+      "GET",
+      "",
+      true,
+    )
+    expect(t4.status).toBe("success")
+    expect(t4.screenshot).toBeUndefined()
+  })
+})
+
+describe("orchestrator", () => {
+  const depsFor = (page: unknown): OrchestratorDeps => ({
+    acquireBrowser: async () => freshHandle(page),
+    releaseBrowser: () => {},
+    loadSession: async () => undefined,
+    saveSession: async () => {},
+    invalidateSession: async () => {},
+  })
+
+  test("emits the tier's screenshot on the scrape result when requested", async () => {
+    const { page } = makePage()
+
+    const result = await scrape(
+      { url: "https://example.com", skipHttp: true, maxTier: 3, maxTimeout: 4_000, screenshot: true },
+      depsFor(page),
+    )
+
+    expect(result.tier).toBe(3)
+    expect(result.screenshot).toBe(JPEG_BASE64)
+  })
+
+  test("omits the screenshot by default", async () => {
+    const { page, screenshotCalls } = makePage()
+
+    const result = await scrape(
+      { url: "https://example.com", skipHttp: true, maxTier: 3, maxTimeout: 4_000 },
+      depsFor(page),
+    )
+
+    expect(result.tier).toBe(3)
+    expect(result.screenshot).toBeUndefined()
+    expect(screenshotCalls).toHaveLength(0)
+  })
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,6 +27,10 @@ export interface ScrapeRequest {
   body?: string
   // Strict per-request route: target traffic must use this proxy and never fall back direct.
   proxy?: string
+  // Opt-in viewport screenshot from the browser tiers (2-4), returned as
+  // `ScrapeResult.screenshot`. Off by default — it costs a settle wait and payload
+  // size. Tier 1 is a plain HTTP fetch and never produces one.
+  screenshot?: boolean
 }
 
 export interface TierResult {
@@ -58,6 +62,9 @@ export interface ScrapeResult {
   responseHeaders?: Record<string, string>
   // Convenience: extracted Content-Type header. Same as responseHeaders['content-type'].
   contentType?: string
+  // Base64 JPEG of the viewport, present only when the request asked for it and a
+  // browser tier served the page. No `data:` prefix.
+  screenshot?: string
 }
 
 export interface SessionData {


### PR DESCRIPTION
## Summary

Supersedes #99 by carrying forward Ethan Mandel's viewport screenshot contribution and adapting it to the current `dev` branch.

- adds opt-in `screenshot: true` to the native `/scrape` API
- returns a base64 JPEG viewport capture from browser tiers 2–4 only
- keeps Tier 1 behavior unchanged; use `skipHttp: true` to force a browser attempt
- preserves the outbound URL validator and keeps MCP `scrape_url` text-only
- bounds settle/capture work by the remaining request budget
- keeps capture failures, timeouts, and images over 4 MB best-effort
- prevents the screenshot payload from being duplicated in `timings`
- validates that `screenshot`, when supplied, is boolean
- documents the `SCREENSHOT_*` settings in `.env.example` and the docs

## Attribution

This replacement carries forward the original contribution from #99 by @emandel2630. The first commit retains Ethan's authorship and original commit message; the second commit contains the current-branch safety and compatibility adaptations.

## Verification

- `bun run verify` (301 tests, typechecks, checks, web build, docs build)
- focused screenshot/API validation suite after the final Tier 1 assertion: 26 tests passed
