### PR TITLE
docs: fix Compose troubleshooting for Prowlarr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional viewport screenshot: `screenshot: true` on `POST /scrape` returns a base64 JPEG of the viewport in `ScrapeResult.screenshot`, captured by the browser tiers (2-4) immediately before the HTML read so image and markup describe the same moment. Off by default; a stock request attaches nothing and does no extra work. Settle wait, capture timeout, JPEG quality, and maximum image size are bounded and tunable via `SCREENSHOT_*`, and a capture failure leaves the field unset rather than failing the scrape.
 
 ### Fixed
+- Correct Docker troubleshooting commands to use the actual `trawl` Compose service name, and distinguish Prowlarr's always-available FlareSolverr API on port 8191 from the opt-in forward proxy on port 8192 (#96).
 - Wait for the bundled Redis service to pass a `PING` healthcheck before starting TRAWL, preventing a transient Compose startup race from disabling the Tier 2 session cache for the process lifetime (#90).
 - Reap orphaned Camoufox processes in both API container variants by running Bun under Tini (#79).
 - Preserve every upstream `Set-Cookie` field across direct, Tier 1, and browser-backed proxy responses, serializing each cookie as its own HTTP header instead of dropping or malformedly folding repeated values (#64).

--- a/apps/docs/deployment/troubleshooting.md
+++ b/apps/docs/deployment/troubleshooting.md
@@ -7,11 +7,14 @@ description: Common issues and how to fix them.
 
 ## API never becomes ready
 
-**Symptom:** `docker compose logs api` shows browser launches but the API never prints `ready — all N browsers warm`.
+**Symptom:** `docker compose logs trawl` shows browser launches but the API never prints `ready — all N browsers warm`.
 
 **Causes:**
 
-1. **Camoufox binary not installed** — The API Dockerfile runs `bunx camoufox-js fetch`. If this step was skipped (e.g. build cache reuse), rebuild: `docker compose build --no-cache api`.
+1. **Camoufox binary not installed** — The API image normally installs it during publication.
+   The supplied Compose files use a prebuilt image and have no `build` section, so
+   `docker compose build` intentionally does nothing. Pull and recreate the service instead:
+   `docker compose pull trawl && docker compose up -d --force-recreate trawl`.
 2. **shm_size too small** — Ensure `shm_size: 1gb` is set on the API service.
 
 Redis is optional at runtime. If it is unavailable, TRAWL disables the Tier 2 session-cache
@@ -133,6 +136,29 @@ docker compose up -d --force-recreate
 2. Prowlarr can reach the TRAWL container. If they're in different Docker networks, add TRAWL to Prowlarr's network (see [Prowlarr docs](/integrations/prowlarr)).
 3. Run `docker exec prowlarr curl -s http://trawl:8191/health` to verify network reachability from inside the Prowlarr container.
 
+## Prowlarr reports `Unable to connect to proxy`
+
+First identify which TRAWL interface Prowlarr is using:
+
+- **FlareSolverr integration:** configure `http://trawl:8191` under **Settings → Indexers →
+  FlareSolverr**. Port `8191` is the API and does not require `MITM_PROXY_ENABLED`.
+- **HTTP indexer proxy:** port `8192` is disabled by default. Set `MITM_PROXY_ENABLED=true`, recreate
+  the TRAWL service, and configure an HTTP proxy with host `trawl` and port `8192`. HTTPS targets
+  also require TRAWL's CA in the Prowlarr container trust store; see
+  [Proxy client setup](/proxy/client-setup#prowlarr).
+
+The supplied Compose service is named `trawl`, not `api`. Check both interfaces from the Prowlarr
+container when diagnosing Docker networking:
+
+```bash
+docker exec prowlarr curl -fsS http://trawl:8191/health
+docker exec prowlarr curl -fsS --proxy http://trawl:8192 http://neverssl.com/ -o /dev/null
+```
+
+The second command succeeds only when the optional forward proxy is enabled. If either hostname
+lookup fails, attach Prowlarr and TRAWL to the same Docker network before changing application
+settings.
+
 ## High memory usage / OOM kills
 
 Each Camoufox instance uses 350–500 MB. With 3 browsers, expect ~1.5 GB total. If the API is being killed:
@@ -145,7 +171,7 @@ Each Camoufox instance uses 350–500 MB. With 3 browsers, expect ~1.5 GB total.
 
 ```bash
 # Live API logs
-docker compose logs -f api
+docker compose logs -f trawl
 
 # Check Redis keys
 docker compose exec redis redis-cli keys "*"

--- a/apps/docs/getting-started/quick-start.md
+++ b/apps/docs/getting-started/quick-start.md
@@ -38,7 +38,7 @@ This starts two containers:
 The API takes **15–30 seconds** to launch and warm the browser pool. Watch progress:
 
 ```bash
-docker compose logs -f api
+docker compose logs -f trawl
 ```
 
 You'll see:
@@ -115,6 +115,9 @@ http://localhost:8191
 ```
 
 Done. No other configuration changes are needed. TRAWL implements the FlareSolverr v2 API exactly.
+
+This uses the API on port `8191`. Do not configure port `8192` here: that is the separate,
+optional HTTP/HTTPS forward proxy and it is disabled by default.
 
 ---
 

--- a/apps/docs/integrations/prowlarr.md
+++ b/apps/docs/integrations/prowlarr.md
@@ -9,6 +9,9 @@ TRAWL implements the FlareSolverr v2 API exactly, including the `version: "2.0.0
 
 ## Setup
 
+This is the recommended FlareSolverr-compatible integration. It uses TRAWL's API on port `8191`;
+the optional forward proxy on port `8192` is a separate mode.
+
 1. Open Prowlarr and go to **Settings → Indexers**
 2. Scroll to the **FlareSolverr** section
 3. Set the URL to your TRAWL API address:
@@ -60,8 +63,16 @@ http://172.17.0.1:8191            # Linux Docker default bridge
 
 ## Troubleshooting
 
-**Test fails with "connection refused"**  
-The API container isn't running or the port is wrong. Run `docker compose logs api` and check the port mapping with `docker compose ps`.
+**Test fails with "connection refused"**
+
+The API container isn't running or the port is wrong. Run `docker compose logs trawl` and check the port mapping with `docker compose ps`.
+
+**Prowlarr reports "Unable to connect to proxy"**
+
+If you configured TRAWL under **Settings → Indexer Proxies → HTTP** rather than as a
+FlareSolverr service, you are using the optional forward proxy. Enable it with
+`MITM_PROXY_ENABLED=true`, recreate the `trawl` service, use port `8192`, and install TRAWL's CA in
+the Prowlarr container for HTTPS targets. See [Proxy client setup](/proxy/client-setup#prowlarr).
 
 **Test succeeds but searches still fail**  
 Some indexers use a different domain than their main site. TRAWL caches cookies per hostname — the first request to each subdomain takes the full challenge time.


### PR DESCRIPTION
## Summary

- replace stale Compose service references from api to trawl
- explain that the supplied Compose files use prebuilt images, so recovery uses pull and force-recreate rather than compose build
- distinguish the FlareSolverr API on port 8191 from the opt-in HTTP/HTTPS forward proxy on port 8192
- add concrete Prowlarr connectivity checks for both interfaces

## Verification

- bun run verify
- 359 tests passed
- docs and web builds passed

Fixes #96